### PR TITLE
Remove extraneous comma that invalidated JSON

### DIFF
--- a/static/apps.json
+++ b/static/apps.json
@@ -26,7 +26,7 @@
     "https://provenance-emu.com/images/feature/game-library.png",
     "https://provenance-emu.com/images/feature/force-touch.png",
     "https://provenance-emu.com/images/feature/force-actions.png",
-    "https://provenance-emu.com/images/feature/n64-gameplay.png",
+    "https://provenance-emu.com/images/feature/n64-gameplay.png"
 ]
 }
 ],


### PR DESCRIPTION
Its a very simple issue with a simple solution. Currently the AltStore repo does not work due to this extra comma that should not be there. JSON is rather sensitive.