### PR TITLE
Add blog posts for releases 3.1.0, 3.1.1, and 3.2.1

### DIFF
--- a/content/blog/release3.1.0.md
+++ b/content/blog/release3.1.0.md
@@ -1,10 +1,10 @@
 ---
 title: "Release 3.1.0"
-date: 2025-08-18T17:07:19-00:00
+date: 2025-08-18T17:07:19-05:00
 draft: false
 tags: ["release"]
 type: "post"
-author: "Provenance Team"
+author: "Joe Mattiello"
 authorImage: "images/team/joe.jpg"
 authorSocial:
   - icon : "tf-ion-social-github"

--- a/content/blog/release3.1.1.md
+++ b/content/blog/release3.1.1.md
@@ -1,10 +1,10 @@
 ---
 title: "Release 3.1.1"
-date: 2025-11-08T20:03:01-00:00
+date: 2025-11-08T20:03:01-05:00
 draft: false
 tags: ["release"]
 type: "post"
-author: "Provenance Team"
+author: "Joe Mattiello"
 authorImage: "images/team/joe.jpg"
 authorSocial:
   - icon : "tf-ion-social-github"

--- a/content/blog/release3.2.1.md
+++ b/content/blog/release3.2.1.md
@@ -1,10 +1,10 @@
 ---
 title: "Release 3.2.1"
-date: 2025-11-23T18:54:37-00:00
+date: 2025-11-23T18:54:37-05:00
 draft: false
 tags: ["release"]
 type: "post"
-author: "Provenance Team"
+author: "Joe Mattiello"
 authorImage: "images/team/joe.jpg"
 authorSocial:
   - icon : "tf-ion-social-github"


### PR DESCRIPTION
## Summary
- Add blog post for Release 3.1.0 (Flycast/Dreamcast, Dolphin/GameCube/Wii, RetroAchievements, iCloud Sync v1)
- Add blog post for Release 3.1.1 (bug fixes, contributor credits)
- Add blog post for Release 3.2.1 (iPad skin fixes, controller fixes)

Content sourced from GitHub Release notes. Fills the gap between 3.0.4 and 3.2.0 posts.

Part of #14

## Test plan
- [ ] Verify `hugo --minify` builds successfully
- [ ] Check /blog/ page shows new posts in correct chronological order
- [ ] Verify each post renders correctly with proper formatting
- [ ] Verify download links in posts are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)