### PR TITLE
Add FAQPage JSON-LD schema for rich search results

### DIFF
--- a/themes/small-apps-prov/layouts/partials/jsonld.html
+++ b/themes/small-apps-prov/layouts/partials/jsonld.html
@@ -42,3 +42,30 @@
 }
 </script>
 {{- end }}
+
+{{- /* FAQPage JSON-LD - FAQ section only */ -}}
+{{- if eq .Section "faq" }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {{- $first := true -}}
+    {{- range .Site.Data.faq.faq -}}
+      {{- range .faqList -}}
+        {{- if not $first }},{{ end -}}
+        {{- $first = false }}
+    {
+      "@type": "Question",
+      "name": {{ .question | jsonify }},
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": {{ .answer | jsonify }}
+      }
+    }
+      {{- end -}}
+    {{- end }}
+  ]
+}
+</script>
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds FAQPage structured data schema to the FAQ page
- Enables Google rich results (FAQ accordions in search)
- Part of Epic #11: SEO & Structured Data

## Test plan
- [ ] Verify `hugo --minify` builds successfully
- [ ] Check FAQ page source for valid JSON-LD
- [ ] Test with Google Rich Results Test tool

Generated with [Claude Code](https://claude.com/claude-code)