### PR TITLE
Fix mobile overflow caused by large inline padding

### DIFF
--- a/static/css/provenance-custom.css
+++ b/static/css/provenance-custom.css
@@ -298,6 +298,17 @@ p {
    Service Section
    ======================================== */
 
+/* Service Thumb Image - responsive padding replacement for inline padding-left: 300px */
+.service-thumb-img {
+  padding-left: clamp(0px, 20vw, 300px);
+}
+
+@media (max-width: 991px) {
+  .service-thumb-img {
+    padding-left: 0;
+  }
+}
+
 .service-item {
   padding: 1.5rem;
   border-radius: var(--border-radius);

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -254,7 +254,7 @@
 		<div class="row no-gutters">
 			<div class="col-lg-6 align-self-center">
 				<div class="service-thumb left" data-aos="fade-right">
-					<img class="img-fluid" style="padding-left: 300px" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad">
+					<img class="img-fluid service-thumb-img" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad">
 				</div>
 			</div>
 			<div class="col-lg-5 mr-auto align-self-center">


### PR DESCRIPTION
## Summary
- Removed inline `padding-left: 300px` from the service section image (`<img>` in the "38+ Game Systems" section) that caused horizontal overflow on mobile devices
- Replaced with a responsive `.service-thumb-img` CSS class using `clamp(0px, 20vw, 300px)` for fluid scaling on desktop
- Added a media query to remove padding entirely on screens below 991px (tablet/mobile breakpoint matching Bootstrap's `col-lg` threshold)

## Changes
- `themes/small-apps-prov/layouts/index.html` -- removed inline style, added `service-thumb-img` class
- `static/css/provenance-custom.css` -- added responsive `.service-thumb-img` styles with `clamp()` and mobile media query

## Test plan
- [ ] Verify homepage loads correctly on desktop (image should still have left padding, scaling with viewport)
- [ ] Verify no horizontal scroll/overflow on mobile viewports (320px-768px)
- [ ] Verify the "38+ Game Systems" section image displays properly at tablet breakpoints (768px-991px)
- [ ] Run `hugo --minify` build successfully

Relates to Epic #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)