### PR TITLE
Add App Store badge graphics and improve download section

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -28,12 +28,16 @@ banner:
   button:
     btnText : "Get on App Store"
     URL : "https://apps.apple.com/us/app/provenance-app/id1596862805"
+    badge: "images/badges/app-store-badge.svg"
     btnText2: 'Get on AltStore'
     URL2: "altstore"
+    badge2: "images/badges/altstore-badge.svg"
     btnText3: 'Download IPA'
     URL3: 'https://github.com/Provenance-Emu/Provenance/releases'
+    badge3: "images/badges/github-badge.svg"
     btnText4: 'Get on SideStore'
     URL4: 'sidestore'
+    badge4: "images/badges/sidestore-badge.svg"
 
 
 # banner-feature
@@ -301,9 +305,12 @@ download:
     - btnText : "App Store"
       icon : "tf-ion-social-apple"
       URL : "https://apps.apple.com/us/app/provenance-app/id1596862805"
+      badge : "images/badges/app-store-badge.svg"
     - btnText : "AltStore"
       icon : "tf-ion-ios-cloud-download"
       URL : "altstore"
+      badge : "images/badges/altstore-badge.svg"
     - btnText : "Download IPA"
       icon : "tf-ion-android-download"
       URL : "https://github.com/Provenance-Emu/Provenance/releases"
+      badge : "images/badges/github-badge.svg"

--- a/static/css/provenance-custom.css
+++ b/static/css/provenance-custom.css
@@ -371,6 +371,78 @@ p {
 }
 
 /* ========================================
+   Download Badge Styles
+   ======================================== */
+
+/* Badge link - shared styles */
+.badge-link {
+  display: inline-block;
+  transition: var(--transition-smooth);
+  text-decoration: none;
+  line-height: 0;
+}
+
+.badge-link:hover {
+  transform: translateY(-3px);
+  filter: brightness(1.15);
+}
+
+.badge-link:active {
+  transform: translateY(-1px);
+}
+
+/* Badge images */
+.download-badge {
+  display: block;
+  height: auto;
+  width: auto;
+}
+
+/* Hero section badges */
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.download-badge-hero {
+  height: 46px;
+  width: auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  transition: var(--transition-smooth);
+}
+
+.badge-link-hero:hover .download-badge-hero {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+/* Download section badges */
+.download-badges-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.download-badge-section {
+  height: 56px;
+  width: auto;
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  transition: var(--transition-smooth);
+}
+
+.badge-link-download:hover .download-badge-section {
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+}
+
+/* ========================================
    Gradient Banner Enhancements
    ======================================== */
 
@@ -445,6 +517,41 @@ p {
   .comparison-table th,
   .comparison-table td {
     padding: 0.75rem 0.5rem;
+  }
+
+  /* Badge responsive - center and stack on mobile */
+  .hero-badges {
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .download-badge-hero {
+    height: 42px;
+  }
+
+  .download-badges-row {
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .download-badge-section {
+    height: 50px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 991px) {
+  /* Tablet: keep row but slightly smaller badges */
+  .hero-badges {
+    gap: 10px;
+  }
+
+  .download-badge-hero {
+    height: 40px;
+  }
+
+  .download-badge-section {
+    height: 50px;
   }
 }
 

--- a/static/images/badges/altstore-badge.svg
+++ b/static/images/badges/altstore-badge.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60" width="180" height="60">
+  <defs>
+    <linearGradient id="bg-alt" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#2b2b2b"/>
+      <stop offset="100%" style="stop-color:#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="60" rx="10" ry="10" fill="url(#bg-alt)"/>
+  <rect width="180" height="60" rx="10" ry="10" fill="none" stroke="#a6a6a6" stroke-width="1"/>
+  <!-- AltStore diamond icon -->
+  <g transform="translate(14, 12)">
+    <path fill="#ffffff" d="M17 0L34 17L17 34L0 17L17 0z" opacity="0.9"/>
+    <path fill="#1a1a1a" d="M17 6L28 17L17 28L6 17L17 6z"/>
+    <path fill="#ffffff" d="M17 10L24 17L17 24L10 17L17 10z" opacity="0.9"/>
+  </g>
+  <!-- Text -->
+  <text x="56" y="24" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="0.02em">Get it on</text>
+  <text x="56" y="45" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="600" letter-spacing="-0.01em">AltStore</text>
+</svg>

--- a/static/images/badges/app-store-badge.svg
+++ b/static/images/badges/app-store-badge.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60" width="180" height="60">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a1a"/>
+      <stop offset="100%" style="stop-color:#000000"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="60" rx="10" ry="10" fill="url(#bg)"/>
+  <rect width="180" height="60" rx="10" ry="10" fill="none" stroke="#a6a6a6" stroke-width="1"/>
+  <!-- Apple Logo -->
+  <g transform="translate(14, 12) scale(0.038)">
+    <path fill="#ffffff" d="M633.9 526.1c-1.3 30.3 8.2 60.1 25.8 84.3 17.6 24.2 42.1 41.1 69.8 48.1-5.3 18.3-13.5 35.6-24.2 51.4-16.1 23.7-32.8 47.2-59.2 47.7-25.9 0.5-34.2-15.4-63.8-15.4-29.6 0-38.8 14.9-63.4 15.9-25.4 0.9-44.8-25.6-61.2-49.1-33.5-48.3-59.2-136.5-24.7-196.1 17-29.3 47.5-47.9 81-49.3 25-0.5 48.5 16.8 63.8 16.8 15.3 0 43.9-20.8 74-17.7 12.6 0.5 48 5.1 70.8 38.5-1.8 1.1-42.2 24.7-41.7 73.9M564.5 324.3c13.5-16.4 20.2-37.2 18.8-58.2-18.3 1.9-35.5 10.4-48 24.3-12.3 13.5-23.2 35.5-20.3 56.4 20.3 1.6 40.1-7.1 49.5-22.5"/>
+  </g>
+  <!-- Text -->
+  <text x="52" y="24" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="0.02em">Download on the</text>
+  <text x="52" y="45" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="600" letter-spacing="-0.01em">App Store</text>
+</svg>

--- a/static/images/badges/github-badge.svg
+++ b/static/images/badges/github-badge.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60" width="180" height="60">
+  <defs>
+    <linearGradient id="bg-gh" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#2b2b2b"/>
+      <stop offset="100%" style="stop-color:#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="60" rx="10" ry="10" fill="url(#bg-gh)"/>
+  <rect width="180" height="60" rx="10" ry="10" fill="none" stroke="#a6a6a6" stroke-width="1"/>
+  <!-- GitHub Logo -->
+  <g transform="translate(14, 13)">
+    <path fill="#ffffff" d="M17 0C7.6 0 0 7.6 0 17c0 7.5 4.9 13.9 11.6 16.2 0.9 0.2 1.2-0.4 1.2-0.8 0-0.4 0-1.7 0-3.1-4.7 1-5.7-2-5.7-2-0.8-2-1.9-2.5-1.9-2.5-1.6-1.1 0.1-1 0.1-1 1.7 0.1 2.6 1.8 2.6 1.8 1.5 2.6 4 1.9 5 1.4 0.2-1.1 0.6-1.9 1.1-2.3-3.8-0.4-7.8-1.9-7.8-8.4 0-1.9 0.7-3.4 1.8-4.6-0.2-0.4-0.8-2.2 0.2-4.5 0 0 1.4-0.5 4.7 1.8 1.4-0.4 2.8-0.6 4.3-0.6 1.4 0 2.9 0.2 4.3 0.6 3.3-2.2 4.7-1.8 4.7-1.8 1 2.3 0.3 4.1 0.2 4.5 1.1 1.2 1.8 2.7 1.8 4.6 0 6.6-4 8-7.8 8.4 0.6 0.5 1.2 1.6 1.2 3.2 0 2.3 0 4.2 0 4.7 0 0.5 0.3 1 1.2 0.8C29.1 30.9 34 24.5 34 17 34 7.6 26.4 0 17 0z"/>
+  </g>
+  <!-- Text -->
+  <text x="56" y="24" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="0.02em">Download from</text>
+  <text x="56" y="45" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="600" letter-spacing="-0.01em">GitHub</text>
+</svg>

--- a/static/images/badges/sidestore-badge.svg
+++ b/static/images/badges/sidestore-badge.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60" width="180" height="60">
+  <defs>
+    <linearGradient id="bg-side" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#2b2b2b"/>
+      <stop offset="100%" style="stop-color:#1a1a1a"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="60" rx="10" ry="10" fill="url(#bg-side)"/>
+  <rect width="180" height="60" rx="10" ry="10" fill="none" stroke="#a6a6a6" stroke-width="1"/>
+  <!-- SideStore icon - stylized S -->
+  <g transform="translate(14, 12)">
+    <circle cx="17" cy="17" r="16" fill="none" stroke="#ffffff" stroke-width="2.5" opacity="0.9"/>
+    <path fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" d="M11 13c0-3 3-5 6-5s6 2 6 5-3 4-6 4-6 2-6 5 3 5 6 5 6-2 6-5"/>
+  </g>
+  <!-- Text -->
+  <text x="56" y="24" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="0.02em">Get it on</text>
+  <text x="56" y="45" fill="#ffffff" font-family="-apple-system, 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="600" letter-spacing="-0.01em">SideStore</text>
+</svg>

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -28,12 +28,26 @@
 				<p class="text-white mb-5">{{ .description | safeHTML }}</p>
 				{{ with .button }}
 				{{ $btn := . }}
-				<a href="{{ .URL }}" class="btn font-weight-bold btn-main-md btn-lg" style="font-size: 1.1em; padding: 0.75rem 2rem;">{{ .btnText }}</a>
-				<a href="{{ .URL2 }}" class="btn font-weight-bold btn-main-md ios-only">{{ .btnText2 }}</a>
-				<a href="#" onClick="alert('Open this page from an iOS device.')" class="btn font-weight-bold btn-main-md ios-disable">{{ .btnText2 }}</a>
-				<a href="{{ .URL3 }}" class="btn font-weight-bold btn-main-md">{{ .btnText3 }}</a>
-				{{ with .URL4 }}<a href="{{ . }}" class="btn font-weight-bold btn-main-md ios-only">{{ $btn.btnText4 }}</a>{{ end }}
-				{{ with .URL5 }}<a href="{{ . }}" class="btn font-weight-bold btn-main-md ios-only">{{ $btn.btnText5 }}</a>{{ end }}
+				<div class="hero-badges">
+					<a href="{{ .URL }}" class="badge-link badge-link-hero" title="{{ .btnText }}">
+						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-hero">
+					</a>
+					<a href="{{ .URL2 }}" class="badge-link badge-link-hero ios-only" title="{{ .btnText2 }}">
+						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero">
+					</a>
+					<a href="#" onClick="alert('Open this page from an iOS device.')" class="badge-link badge-link-hero ios-disable" title="{{ .btnText2 }}">
+						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero">
+					</a>
+					<a href="{{ .URL3 }}" class="badge-link badge-link-hero" title="{{ .btnText3 }}">
+						<img src="{{ .badge3 | absURL }}" alt="{{ .btnText3 }}" class="download-badge download-badge-hero">
+					</a>
+					{{ with .URL4 }}<a href="{{ . }}" class="badge-link badge-link-hero ios-only" title="{{ $btn.btnText4 }}">
+						<img src="{{ $btn.badge4 | absURL }}" alt="{{ $btn.btnText4 }}" class="download-badge download-badge-hero">
+					</a>{{ end }}
+					{{ with .URL5 }}<a href="{{ . }}" class="badge-link badge-link-hero ios-only" title="{{ $btn.btnText5 }}">
+						<img src="{{ $btn.badge5 | absURL }}" alt="{{ $btn.btnText5 }}" class="download-badge download-badge-hero">
+					</a>{{ end }}
+				</div>
 				{{ end }}
 			</div>
 			<div class="col-md-6 text-center order-1 order-md-2">
@@ -387,21 +401,18 @@
 <section class="call-to-action-app section bg-blue">
 	<div class="container">
 		<div class="row">
-			<div class="col-lg-12">
+			<div class="col-lg-12 text-center">
 				{{ with .Site.Data.homepage.download }}
 				<h2>{{ .title }}</h2>
 				<p>{{ .description | safeHTML }}</p>
 				{{ end }}
-				<ul class="list-inline">
+				<div class="download-badges-row">
 					{{ range .Site.Data.homepage.download.downloadButton }}
-					<li class="list-inline-item">
-						<a href="{{ htmlEscape .URL }}" class="btn btn-rounded-icon">
-							<i class="{{ .icon }}"></i>
-							{{ .btnText }}
-						</a>
-					</li>
+					<a href="{{ htmlEscape .URL }}" class="badge-link badge-link-download" title="{{ .btnText }}">
+						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-section">
+					</a>
 					{{ end }}
-				</ul>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- Replace plain text download buttons with professional SVG badge graphics in both the hero banner and bottom download section
- Create four matching badge SVGs: App Store, GitHub (IPA), AltStore, and SideStore
- Add responsive CSS for badge layout (flex row on desktop, centered on mobile) with hover effects and consistent sizing
- Hero badges at 46px height, download section badges at 56px height, with proper shadow and hover animations

## Changes
- **static/images/badges/** - New directory with 4 SVG badge files (app-store, github, altstore, sidestore)
- **data/homepage.yml** - Added badge image paths to banner button config and download button entries
- **themes/small-apps-prov/layouts/index.html** - Hero section now uses img badge elements in a flex container instead of text buttons; download section similarly updated
- **static/css/provenance-custom.css** - Added badge link styles, hover effects, responsive breakpoints for mobile/tablet

## Test plan
- [ ] Run hugo --minify to verify build passes (verified locally)
- [ ] Check hero section on desktop: badges should appear in a horizontal row
- [ ] Check hero section on mobile: badges should wrap/center properly
- [ ] Check download section at bottom: badges centered in a row with hover effects
- [ ] Verify AltStore/SideStore badges still show ios-only / ios-disable behavior
- [ ] Confirm badge SVGs render crisply at all resolutions

Refs #12

Generated with [Claude Code](https://claude.com/claude-code)