### PR TITLE
Add Provenance Plus landing page with pricing and features

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -35,10 +35,16 @@ pygmentsStyle = "solarized-dark"
     #     weight = 1
 
     [[menu.main]]
+        identifier = "plus"
+        name = "Plus"
+        url  = "/plus/"
+        weight = 2
+
+    [[menu.main]]
         identifier="blog"
         name = "Blog"
         url  = "/blog/"
-        weight = 2
+        weight = 3
 
     [[menu.main]]
         identifier = "source"
@@ -47,37 +53,37 @@ pygmentsStyle = "solarized-dark"
         pre = "<i class='fab fa-2x fa-github'></i>"
         target = "_blank"
         hrefTargetBlank = true
-        weight = 3
+        weight = 4
 
     [[menu.main]]
         identifier = "docs"
         name = "Docs"
         url  = "https://wiki.provenance-emu.com/"
-        weight = 4
+        weight = 5
 
     [[menu.main]]
         identifier = "faq"
         name = "FAQ"
         url  = "https://wiki.provenance-emu.com/faqs"
-        weight = 5
+        weight = 6
 
     [[menu.main]]
         identifier = "donate"
         name = "Donate"
         url  = "/donate/"
-        weight = 6
+        weight = 7
 
     [[menu.main]]
         identifier = "discord"
         name = "Discord"
         url  = "https://discord.gg/4TK7PU5"
-        weight = 7
+        weight = 8
 
     [[menu.main]]
         identifier = "privacy"
         name = "Privacy Policy"
         url  = "/privacy/"
-        weight = 8
+        weight = 9
 
     # [[menu.main]]
     #     identifier = "contact"

--- a/content/plus/_index.md
+++ b/content/plus/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Provenance Plus"
+date: 2026-03-05T00:00:00-05:00
+description: "Provenance Plus — iCloud sync, beta access, and priority support. Support Provenance development and unlock premium convenience features."
+pageDescription: "Support development and unlock cloud sync, beta access, and priority support."
+---

--- a/data/plus.yml
+++ b/data/plus.yml
@@ -1,0 +1,168 @@
+# Provenance Plus - Data File
+
+hero:
+  enable: true
+  title: "Provenance <span class='plus-highlight'>Plus</span>"
+  subtitle: "Support Development. Unlock Convenience."
+  description: "Provenance is fully functional and free — every emulation feature, every system, every controller. Plus adds cloud sync across all your Apple devices, early beta access, and priority support. Your subscription directly funds ongoing development."
+  btnText: "Get on App Store"
+  btnURL: "https://apps.apple.com/us/app/provenance-app/id1596862805"
+  btnText2: "Learn More"
+  btnURL2: "#features"
+
+features:
+  enable: true
+  title: "What Plus Unlocks"
+  subtitle: "Premium convenience features that enhance your experience"
+  feature:
+    - icon: "fas fa-cloud"
+      title: "iCloud Sync"
+      description: "Sync your entire library, saves, settings, skins, BIOS files, and cover art across iPhone, iPad, Mac, and Apple TV. Start a game on one device, pick up right where you left off on another."
+      highlight: true
+
+    - icon: "fas fa-flask"
+      title: "TestFlight Beta Access"
+      description: "Get early access to new features, upcoming system support, UI improvements, and bug fixes before they hit the App Store. Provide direct feedback on features in development."
+      highlight: true
+
+    - icon: "fas fa-headset"
+      title: "Priority Support"
+      description: "Get faster help from the Provenance team when you need it. Plus subscribers receive priority responses for troubleshooting and feature requests."
+      highlight: true
+
+    - icon: "fas fa-users"
+      title: "Family Sharing"
+      description: "One Provenance Plus subscription covers up to 6 family members through Apple Family Sharing. Everyone in your family gets cloud sync, beta access, and priority support."
+      highlight: false
+
+    - icon: "fas fa-tv"
+      title: "Free on Apple TV"
+      description: "iCloud sync is free on Apple TV by default. tvOS can reclaim app storage at any time, so CloudKit sync is enabled automatically to protect your data from unexpected deletion."
+      highlight: false
+
+    - icon: "fas fa-code-branch"
+      title: "Open Source Supported"
+      description: "Provenance is and always will be open source. Sideloaded builds include all features free. Plus subscriptions on the App Store fund development, infrastructure, and new system support."
+      highlight: false
+
+comparison:
+  enable: true
+  title: "Free vs Plus"
+  subtitle: "Every emulation feature is free. Plus adds convenience and early access."
+  rows:
+    - feature: "All 38+ Emulated Systems"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "Full Emulation (Save States, Cheats, Fast Forward)"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "Shaders & Visual Filters"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "On-Screen Controls & Controller Support"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "Controller Skins"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "RetroAchievements"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "Multiplayer"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "Local Library Management"
+      free: true
+      plus: true
+      category: "core"
+
+    - feature: "iCloud Sync (Library, Saves, Settings, Skins, BIOS, Artwork)"
+      free: false
+      plus: true
+      category: "plus"
+
+    - feature: "TestFlight Beta Access"
+      free: false
+      plus: true
+      category: "plus"
+
+    - feature: "Priority Support"
+      free: false
+      plus: true
+      category: "plus"
+
+    - feature: "Family Sharing (up to 6 members)"
+      free: false
+      plus: true
+      category: "plus"
+
+pricing:
+  enable: true
+  title: "Simple, Transparent Pricing"
+  subtitle: "Choose the plan that works for you. Cancel anytime."
+  plans:
+    - name: "Monthly"
+      price: "$3.99"
+      period: "/month"
+      description: "Try it out"
+      highlight: false
+
+    - name: "Annual"
+      price: "$39.99"
+      period: "/year"
+      description: "Save 17% - best for regular users"
+      highlight: true
+      badge: "Most Popular"
+
+    - name: "Lifetime"
+      price: "$99.99"
+      period: "one-time"
+      description: "Pay once, keep forever"
+      highlight: false
+      badge: "Best Value"
+
+  note: "Subscribe from within the Provenance app: Settings > Provenance Plus. All plans include Family Sharing."
+  appStoreURL: "https://apps.apple.com/us/app/provenance-app/id1596862805"
+
+faq:
+  enable: true
+  title: "Frequently Asked Questions"
+  items:
+    - question: "Do I lose my data if I cancel Plus?"
+      answer: "No. All your local data (ROMs, saves, settings) stays on your device. You lose the ability to sync across devices, but previously synced data remains on each device where it was downloaded."
+
+    - question: "Can I use Plus on multiple devices?"
+      answer: "Yes. Your subscription is tied to your Apple ID. Sign in on any device and your Plus benefits follow you. Plus also supports Family Sharing for up to 6 family members."
+
+    - question: "Why is Apple TV sync free?"
+      answer: "tvOS aggressively reclaims storage from apps, which can delete your ROMs and saves without warning. To protect users from unexpected data loss, iCloud sync is included free and enabled by default on Apple TV."
+
+    - question: "Is sideloading free forever?"
+      answer: "Yes. If you sideload or build from source, all features (including those that are Plus-only on the App Store) are free. Provenance is open source — Plus subscriptions on the App Store support development."
+
+    - question: "What happens to my synced data if my subscription lapses?"
+      answer: "Your data stays on every device it was synced to. You just won't be able to sync new changes until you resubscribe. Nothing is deleted."
+
+    - question: "How do I restore my purchase on a new device?"
+      answer: "Your subscription restores automatically when you sign in with the same Apple ID. You can also go to Settings > Provenance Plus > Restore Purchases in the app."
+
+cta:
+  enable: true
+  title: "Ready to Go Plus?"
+  description: "Support Provenance development and unlock cloud sync across all your Apple devices."
+  btnText: "Download on the App Store"
+  btnURL: "https://apps.apple.com/us/app/provenance-app/id1596862805"

--- a/static/css/provenance-custom.css
+++ b/static/css/provenance-custom.css
@@ -507,3 +507,379 @@ footer .socialIcon a:hover {
   transform: translateY(-3px);
   color: #667eea !important;
 }
+
+/* ========================================
+   Provenance Plus Page
+   ======================================== */
+
+/* Plus Hero */
+.plus-hero {
+  padding: 7rem 0 5rem;
+  background: linear-gradient(135deg, #162434 0%, #1e3a5f 40%, #667eea 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.plus-hero::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.04'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  pointer-events: none;
+}
+
+.plus-highlight {
+  background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.plus-hero .btn-outline-light {
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  padding: 0.9rem 2rem;
+  font-size: 1.05rem;
+  background: transparent;
+  box-shadow: none;
+}
+
+.plus-hero .btn-outline-light:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.8);
+  box-shadow: none;
+}
+
+/* Plus Features */
+.plus-features {
+  padding: 5rem 0;
+  background: #fff;
+}
+
+.plus-feature-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--border-radius);
+  padding: 2rem;
+  height: 100%;
+  transition: var(--transition-smooth);
+  position: relative;
+}
+
+.plus-feature-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+  border-color: transparent;
+}
+
+.plus-feature-highlight {
+  border-color: rgba(102, 126, 234, 0.3);
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.03) 0%, rgba(118, 75, 162, 0.03) 100%);
+}
+
+.plus-feature-highlight:hover {
+  border-color: rgba(102, 126, 234, 0.5);
+}
+
+.plus-feature-icon {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
+  margin-bottom: 1.25rem;
+  transition: var(--transition-smooth);
+}
+
+.plus-feature-card:hover .plus-feature-icon {
+  background: var(--primary-gradient);
+}
+
+.plus-feature-icon i {
+  font-size: 1.5rem;
+  background: var(--primary-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  transition: var(--transition-smooth);
+}
+
+.plus-feature-card:hover .plus-feature-icon i {
+  -webkit-text-fill-color: white;
+  background: none;
+}
+
+.plus-feature-card h4 {
+  font-size: 1.2rem;
+  color: #1a202c;
+  margin-bottom: 0.75rem;
+}
+
+.plus-feature-card p {
+  font-size: 0.95rem;
+  color: #4a5568;
+  line-height: 1.6;
+  margin-bottom: 0;
+}
+
+.plus-badge {
+  display: inline-block;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 20px;
+}
+
+/* Plus Comparison Table */
+.plus-comparison {
+  padding: 5rem 0;
+}
+
+.plus-comparison-table {
+  background: #fff;
+}
+
+.plus-comparison-table thead th {
+  background: #162434;
+  color: #fff;
+  border: none;
+}
+
+.plus-column-header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+  position: relative;
+}
+
+.plus-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success-color);
+  font-size: 0.85rem;
+}
+
+.plus-check-gold {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.15) 0%, rgba(118, 75, 162, 0.15) 100%);
+  color: #667eea;
+  font-size: 0.85rem;
+}
+
+.plus-dash {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #f1f5f9;
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+.plus-exclusive-row {
+  background: linear-gradient(90deg, rgba(102, 126, 234, 0.04) 0%, rgba(118, 75, 162, 0.04) 100%);
+}
+
+.plus-exclusive-row:hover {
+  background: linear-gradient(90deg, rgba(102, 126, 234, 0.08) 0%, rgba(118, 75, 162, 0.08) 100%) !important;
+}
+
+/* Plus Pricing */
+.plus-pricing {
+  padding: 5rem 0;
+  background: #fff;
+}
+
+.plus-pricing-card {
+  background: #fff;
+  border: 2px solid #e2e8f0;
+  border-radius: var(--border-radius);
+  padding: 2.5rem 2rem;
+  text-align: center;
+  height: 100%;
+  transition: var(--transition-smooth);
+  position: relative;
+}
+
+.plus-pricing-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+}
+
+.plus-pricing-highlight {
+  border-color: #667eea;
+  box-shadow: var(--shadow-md);
+}
+
+.plus-pricing-highlight:hover {
+  border-color: #764ba2;
+}
+
+.plus-pricing-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.3rem 1rem;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.plus-pricing-name {
+  font-size: 1.25rem;
+  color: #1a202c;
+  margin-bottom: 1.25rem;
+}
+
+.plus-pricing-price {
+  margin-bottom: 1rem;
+}
+
+.plus-price-amount {
+  font-size: 2.5rem;
+  font-weight: 800;
+  background: var(--primary-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
+}
+
+.plus-price-period {
+  font-size: 1rem;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.plus-pricing-description {
+  font-size: 0.95rem;
+  color: #64748b;
+  margin-bottom: 0;
+}
+
+/* Plus FAQ */
+.plus-faq {
+  padding: 5rem 0;
+}
+
+.plus-faq .block {
+  border-radius: var(--border-radius);
+}
+
+.plus-faq .item-link a {
+  font-weight: 600;
+  color: #1a202c;
+  padding: 1.25rem 0;
+  display: block;
+  border-bottom: 1px solid #e2e8f0;
+  transition: var(--transition-smooth);
+}
+
+.plus-faq .item-link a:hover {
+  color: #667eea;
+}
+
+.plus-faq .accordion-block p {
+  color: #4a5568;
+  padding: 0.5rem 0 1rem;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+/* Plus CTA */
+.plus-cta {
+  padding: 5rem 0;
+  background: linear-gradient(135deg, #162434 0%, #1e3a5f 50%, #667eea 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.plus-cta::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.04'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  pointer-events: none;
+}
+
+.plus-cta-btn {
+  padding: 1rem 2.5rem !important;
+  font-size: 1.1rem !important;
+  border-radius: var(--border-radius);
+  background: white;
+  color: #162434 !important;
+  border: none;
+  position: relative;
+  z-index: 1;
+}
+
+.plus-cta-btn:hover {
+  background: #f0f0f0;
+  color: #667eea !important;
+  box-shadow: var(--shadow-lg) !important;
+}
+
+/* Plus Page Mobile Responsiveness */
+@media (max-width: 768px) {
+  .plus-hero {
+    padding: 5rem 0 3rem;
+  }
+
+  .plus-features,
+  .plus-comparison,
+  .plus-pricing,
+  .plus-faq,
+  .plus-cta {
+    padding: 3rem 0;
+  }
+
+  .plus-pricing-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .plus-price-amount {
+    font-size: 2rem;
+  }
+
+  .plus-feature-card {
+    padding: 1.5rem;
+  }
+
+  .plus-comparison-table {
+    overflow-x: auto;
+  }
+
+  .plus-comparison-table table {
+    min-width: 500px;
+  }
+}

--- a/themes/small-apps-prov/layouts/plus/list.html
+++ b/themes/small-apps-prov/layouts/plus/list.html
@@ -1,0 +1,223 @@
+{{ define "main" }}
+
+{{ "<!-- Plus Hero Section -->" | safeHTML }}
+{{ with .Site.Data.plus.hero }}
+{{ if .enable }}
+<section class="section plus-hero gradient-banner">
+  <div class="shapes-container">
+    <div class="shape" data-aos="fade-down-left" data-aos-duration="1500" data-aos-delay="100"></div>
+    <div class="shape" data-aos="fade-down" data-aos-duration="1000" data-aos-delay="100"></div>
+    <div class="shape" data-aos="fade-up-right" data-aos-duration="1000" data-aos-delay="200"></div>
+    <div class="shape" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200"></div>
+    <div class="shape" data-aos="fade-down-left" data-aos-duration="1000" data-aos-delay="100"></div>
+    <div class="shape" data-aos="fade-down-left" data-aos-duration="1000" data-aos-delay="100"></div>
+    <div class="shape" data-aos="zoom-in" data-aos-duration="1000" data-aos-delay="300"></div>
+    <div class="shape" data-aos="fade-down-right" data-aos-duration="500" data-aos-delay="200"></div>
+  </div>
+  <div class="container">
+    <div class="row align-items-center justify-content-center">
+      <div class="col-lg-8 text-center">
+        <h1 class="text-white font-weight-bold mb-3" data-aos="fade-up">{{ .title | safeHTML }}</h1>
+        <p class="text-white lead mb-3" data-aos="fade-up" data-aos-delay="100" style="font-size: 1.4rem; font-weight: 600; opacity: 0.95;">{{ .subtitle }}</p>
+        <p class="text-white mb-5" data-aos="fade-up" data-aos-delay="200" style="font-size: 1.1rem; opacity: 0.9; max-width: 640px; margin: 0 auto;">{{ .description }}</p>
+        <div data-aos="fade-up" data-aos-delay="300">
+          <a href="{{ .btnURL }}" target="_blank" class="btn font-weight-bold btn-main-md btn-lg mr-3 mb-2">
+            <span><i class="fab fa-app-store-ios mr-2"></i>{{ .btnText }}</span>
+          </a>
+          <a href="{{ .btnURL2 }}" class="btn btn-outline-light font-weight-bold btn-lg mb-2">
+            {{ .btnText2 }}
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Plus Hero Section -->" | safeHTML }}
+
+{{ "<!-- Plus Features Section -->" | safeHTML }}
+{{ with .Site.Data.plus.features }}
+{{ if .enable }}
+<section class="section plus-features" id="features">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center mb-5">
+        <h2 class="font-weight-bold" data-aos="fade-up">{{ .title }}</h2>
+        <p class="text-muted" data-aos="fade-up" data-aos-delay="100">{{ .subtitle }}</p>
+      </div>
+    </div>
+    <div class="row">
+      {{ range $index, $feature := .feature }}
+      <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="{{ mul $index 100 }}">
+        <div class="plus-feature-card{{ if .highlight }} plus-feature-highlight{{ end }}">
+          <div class="plus-feature-icon">
+            <i class="{{ .icon }}"></i>
+          </div>
+          <h4>{{ .title }}</h4>
+          <p>{{ .description }}</p>
+          {{ if .highlight }}
+          <span class="plus-badge">Plus</span>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Plus Features Section -->" | safeHTML }}
+
+{{ "<!-- Comparison Table Section -->" | safeHTML }}
+{{ with .Site.Data.plus.comparison }}
+{{ if .enable }}
+<section class="section plus-comparison bg-gray" id="comparison">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center mb-5">
+        <h2 class="font-weight-bold" data-aos="fade-up">{{ .title }}</h2>
+        <p class="text-muted" data-aos="fade-up" data-aos-delay="100">{{ .subtitle }}</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-10 m-auto" data-aos="fade-up" data-aos-delay="200">
+        <div class="plus-comparison-table comparison-table">
+          <table class="table">
+            <thead>
+              <tr>
+                <th style="width: 60%;">Feature</th>
+                <th class="text-center" style="width: 20%;">Free</th>
+                <th class="text-center plus-column-header" style="width: 20%;">Plus</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{ range .rows }}
+              <tr class="{{ if eq .category "plus" }}plus-exclusive-row{{ end }}">
+                <td>
+                  <strong>{{ .feature }}</strong>
+                </td>
+                <td class="text-center">
+                  {{ if .free }}
+                  <span class="plus-check"><i class="fas fa-check"></i></span>
+                  {{ else }}
+                  <span class="plus-dash"><i class="fas fa-minus"></i></span>
+                  {{ end }}
+                </td>
+                <td class="text-center">
+                  {{ if .plus }}
+                  <span class="plus-check-gold"><i class="fas fa-check"></i></span>
+                  {{ else }}
+                  <span class="plus-dash"><i class="fas fa-minus"></i></span>
+                  {{ end }}
+                </td>
+              </tr>
+              {{ end }}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Comparison Table Section -->" | safeHTML }}
+
+{{ "<!-- Pricing Section -->" | safeHTML }}
+{{ with .Site.Data.plus.pricing }}
+{{ if .enable }}
+<section class="section plus-pricing" id="pricing">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center mb-5">
+        <h2 class="font-weight-bold" data-aos="fade-up">{{ .title }}</h2>
+        <p class="text-muted" data-aos="fade-up" data-aos-delay="100">{{ .subtitle }}</p>
+      </div>
+    </div>
+    <div class="row justify-content-center">
+      {{ range $index, $plan := .plans }}
+      <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="{{ mul $index 100 }}">
+        <div class="plus-pricing-card{{ if .highlight }} plus-pricing-highlight{{ end }}">
+          {{ with .badge }}
+          <div class="plus-pricing-badge">{{ . }}</div>
+          {{ end }}
+          <h3 class="plus-pricing-name">{{ .name }}</h3>
+          <div class="plus-pricing-price">
+            <span class="plus-price-amount">{{ .price }}</span>
+            <span class="plus-price-period">{{ .period }}</span>
+          </div>
+          <p class="plus-pricing-description">{{ .description }}</p>
+        </div>
+      </div>
+      {{ end }}
+    </div>
+    <div class="row">
+      <div class="col-12 text-center mt-3" data-aos="fade-up">
+        <p class="text-muted" style="font-size: 0.95rem;">{{ .note }}</p>
+        <a href="{{ .appStoreURL }}" target="_blank" class="btn font-weight-bold btn-main-md btn-lg mt-3">
+          <span><i class="fab fa-app-store-ios mr-2"></i>Download Provenance</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Pricing Section -->" | safeHTML }}
+
+{{ "<!-- Plus FAQ Section -->" | safeHTML }}
+{{ with .Site.Data.plus.faq }}
+{{ if .enable }}
+<section class="section plus-faq bg-gray" id="faq">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center mb-5">
+        <h2 class="font-weight-bold" data-aos="fade-up">{{ .title }}</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-8 m-auto">
+        <div class="block shadow" data-aos="fade-up" data-aos-delay="100">
+          <div id="plus-accordions" data-children=".item">
+            {{ range $index, $item := .items }}
+            <div class="item">
+              <div class="item-link">
+                <a data-toggle="collapse" data-parent="#plus-accordions" href="#plus-faq-{{ $index }}">{{ .question }}</a>
+              </div>
+              <div id="plus-faq-{{ $index }}" class="collapse accordion-block">
+                <p>{{ .answer }}</p>
+              </div>
+            </div>
+            {{ end }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Plus FAQ Section -->" | safeHTML }}
+
+{{ "<!-- Plus CTA Section -->" | safeHTML }}
+{{ with .Site.Data.plus.cta }}
+{{ if .enable }}
+<section class="section plus-cta">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-8 m-auto text-center" data-aos="fade-up">
+        <h2 class="text-white font-weight-bold mb-3">{{ .title }}</h2>
+        <p class="text-white mb-4" style="opacity: 0.9; font-size: 1.15rem;">{{ .description }}</p>
+        <a href="{{ .btnURL }}" target="_blank" class="btn btn-light font-weight-bold btn-lg plus-cta-btn">
+          <i class="fab fa-app-store-ios mr-2"></i>{{ .btnText }}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+{{ end }}
+{{ "<!-- End Plus CTA Section -->" | safeHTML }}
+
+{{ end }}


### PR DESCRIPTION
## Summary
- Creates a dedicated `/plus` landing page showcasing Provenance Plus subscription features, sourced from the official Provenance wiki documentation
- Adds hero section with gradient background, feature grid (iCloud Sync, TestFlight Beta Access, Priority Support, Family Sharing, free Apple TV sync, open source ethos), side-by-side Free vs Plus comparison table, pricing cards ($3.99/mo, $39.99/yr, $99.99 lifetime), FAQ accordion, and App Store CTA
- Implements data-driven architecture (`data/plus.yml` + `themes/small-apps-prov/layouts/plus/list.html`) consistent with existing site patterns
- Adds "Plus" entry to main navigation menu and extends `provenance-custom.css` with ~375 lines of responsive styles matching the site's dark theme

Part of Epic #13

## Files Changed
- `data/plus.yml` -- All page content (hero, features, comparison, pricing, FAQ, CTA)
- `content/plus/_index.md` -- Hugo content stub with front matter
- `themes/small-apps-prov/layouts/plus/list.html` -- Page layout template
- `static/css/provenance-custom.css` -- Plus page styles (feature cards, comparison table, pricing cards, FAQ, CTA)
- `config.toml` -- Added Plus menu entry, re-weighted existing items

## Test plan
- [ ] Verify `hugo --minify` builds without errors (confirmed locally)
- [ ] Check `/plus/` page renders all sections (hero, features, comparison, pricing, FAQ, CTA)
- [ ] Verify responsive layout on mobile viewports
- [ ] Confirm "Plus" appears in the navigation menu between Home and Blog
- [ ] Test App Store links open correctly
- [ ] Test FAQ accordion expand/collapse behavior
- [ ] Verify AOS scroll animations trigger correctly on each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)