### PR TITLE
Add canonical URLs and improve meta descriptions site-wide

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -167,7 +167,7 @@ pygmentsStyle = "solarized-dark"
     address = ""
     home = "Home"
     # Meta data
-    description = "iOS & tvOS multi-emulator frontend, supporting various Atari, Bandai, NEC, Nintendo, Sega, SNK and Sony console systems."
+    description = "Provenance is a free, open-source multi-system emulator for iPhone, iPad, and Apple TV. Play retro games from 38+ consoles — SNES, PlayStation, N64, GBA, and more. No jailbreak required."
     # google map
     #gmapAPI = "https://maps.googleapis.com/maps/api/js?key=KEY&libraries=places"
     #mapLatitude = "51.5223477"

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "About Provenance"
 date: 2021-07-19T23:37:17-05:00
-description: ""
-pageDescription : ""
+description: "About Provenance — the free, open-source multi-system emulator for iOS and tvOS. Built by the community since 2016, supporting 38+ retro consoles including SNES, PlayStation, N64, and more."
+pageDescription: "The story behind Provenance, the community-driven open-source emulator for iPhone, iPad, and Apple TV."
 ---

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions"
 date: 2019-02-28T12:35:54+06:00
-description: ""
-pageDescription : ""
+description: "Answers to common questions about Provenance — the free, open-source retro game emulator for iPhone, iPad, and Apple TV. Installation, supported systems, controllers, and more."
+pageDescription: "Common questions about installing Provenance, supported consoles, controllers, and Provenance Plus."
 ---
 

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -3,9 +3,13 @@
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
+  {{- $desc := .Description | default .Summary | default .Site.Params.description -}}
+  <meta name="description" content="{{ $desc | plainify | htmlEscape | truncate 160 }}">
   {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ hugo.Generator }}
+
+  {{ "<!-- Canonical URL -->" | safeHTML }}
+  <link rel="canonical" href="{{ .Permalink }}">
 
   {{ "<!-- Page title -->" | safeHTML }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` to `head.html` for all pages (prevents duplicate content SEO penalties)
- Improve meta description fallback: page `.Description` → `.Summary` → site default
- Update site-level description from generic to keyword-rich copy targeting iOS emulator searches
- Add meaningful descriptions to FAQ and About `_index.md` front matter (were empty)

## Test plan
- [ ] Hugo builds without errors (`hugo --minify`)
- [ ] `<link rel="canonical">` appears in `<head>` on all pages
- [ ] Homepage meta description contains iOS emulator keywords
- [ ] FAQ page has its own description (not the generic site description)
- [ ] Blog post pages use their own descriptions/summaries

## Part of
- Part of #26
- Part of #27