### PR TITLE
Prevent premature epic issue auto-close

### DIFF
--- a/.github/workflows/protect-epics.yml
+++ b/.github/workflows/protect-epics.yml
@@ -1,0 +1,41 @@
+name: Protect Epic Issues
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  reopen-epic:
+    # Only act on issues with the 'epic' label
+    if: contains(github.event.issue.labels.*.name, 'epic')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Reopen epic issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'open'
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                '## ⚠️ Epic Auto-Reopened',
+                '',
+                'This issue is marked as an **Epic** and was automatically reopened.',
+                '',
+                'Epic issues track multiple tasks across many PRs and should only be closed manually',
+                'once **all** tasks in the checklist are complete.',
+                '',
+                'If a PR references this epic, use `Part of #' + context.issue.number + '` instead of `Closes #' + context.issue.number + '`.',
+              ].join('\n')
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,26 @@ All in `themes/small-apps-prov/layouts/`:
 ### Submodules
 
 Clone with `--recursive` or run `git submodule update --init --recursive` after cloning. Required for themes to resolve.
+
+## GitHub Issues & PR Conventions
+
+### Epic Issues
+Issues labeled `epic` are parent tracking issues that group multiple related PRs. They must **never** be auto-closed by a PR merge.
+
+- **NEVER** use `Closes #N`, `Fixes #N`, or `Resolves #N` when referencing an epic issue in a PR description.
+- **ALWAYS** use `Part of #N` or `Related to #N` when a PR addresses work from an epic.
+- Child/sub-issues (individual tasks) CAN be closed by PRs using `Closes #N`.
+- If you create a PR that fully completes all tasks in an epic, manually close the epic after human review — do not rely on keyword auto-close.
+
+### PR Description Template
+```
+## Summary
+- Brief bullets of what changed
+
+## Part of
+- Part of #N (epic title)
+
+## Test plan
+- [ ] Hugo builds without errors
+- [ ] Page renders correctly at localhost:1313
+```


### PR DESCRIPTION
## Summary
- Add `.github/workflows/protect-epics.yml`: automatically reopens any issue labeled `epic` if it gets closed (e.g. by GitHub's "Closes #N" keyword detection on PR merge), and posts a comment explaining the correct PR reference syntax
- Update `CLAUDE.md` with explicit PR conventions: use `Part of #N` for epic issues, never `Closes #N`; includes a PR description template

## Root cause
PR #17 used `Closes #15` in its description, which caused GitHub to auto-close Epic #15 when that PR was merged. The epic had remaining tasks and needed to stay open.

## Test plan
- [ ] Workflow file is valid YAML
- [ ] Hugo builds without errors (workflow files don't affect Hugo build)
- [ ] Test: close an epic issue manually → it should auto-reopen within ~30 seconds with a comment

## Part of
- Fixes epic auto-close issue reported by user (epics #11–#15)