### PR TITLE
Enable recent blog posts section on homepage

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -273,9 +273,9 @@ pygmentsStyle = "solarized-dark"
         subtitle = ""
 
     [params.recent_posts]
-        enable = false
+        enable = true
         title = "From our blog"
-        subtitle = "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo."
+        subtitle = "Release notes, development updates, and news about Provenance."
 
     # Plugins
     [params.plugins]


### PR DESCRIPTION
## Summary
- Enable the `[params.recent_posts]` section in `config.toml` (was `enable = false`)
- Replace lorem ipsum placeholder subtitle with real descriptive copy

The "From our blog" section will now appear on the homepage, showing the most recent blog posts. This is driven by the theme's existing template — no layout changes needed.

## Test plan
- [ ] Hugo builds without errors
- [ ] "From our blog" section appears on homepage at localhost:1313
- [ ] Recent blog posts (3.2.1, 3.1.1, 3.1.0, etc.) are shown
- [ ] Section is responsive on mobile

## Part of
- Part of #25
- Part of #14