### PR TITLE
Add Provenance Plus callouts to 3.x release blog posts

### DIFF
--- a/content/blog/release3.1.0.md
+++ b/content/blog/release3.1.0.md
@@ -69,4 +69,10 @@ For a complete list of changes, please visit our [GitHub release page](https://g
 
 ---
 
+## Provenance Plus
+
+The new iCloud Sync feature in 3.1.0 is just the beginning. **[Provenance Plus](/plus/)** takes it further with full cross-device iCloud sync, TestFlight beta access so you get new features first, and priority support — all while directly funding the continued development of Provenance. Subscribe from within the app: *Settings > Provenance Plus*.
+
+---
+
 Thank you for being part of the Provenance community. Happy gaming!

--- a/content/blog/release3.1.1.md
+++ b/content/blog/release3.1.1.md
@@ -68,4 +68,10 @@ For a complete list of changes, please visit our [GitHub release page](https://g
 
 ---
 
+## Provenance Plus
+
+Enjoying Provenance? **[Provenance Plus](/plus/)** adds iCloud sync across all your Apple devices, TestFlight beta access, and priority support — while directly funding ongoing development. Your subscription helps keep the fixes and improvements coming. Subscribe from within the app: *Settings > Provenance Plus*.
+
+---
+
 Thank you for being part of the Provenance community. Happy gaming!

--- a/content/blog/release3.2.1.md
+++ b/content/blog/release3.2.1.md
@@ -54,4 +54,10 @@ For a complete list of changes, please visit our [GitHub release page](https://g
 
 ---
 
+## Provenance Plus
+
+Love what the team is building? **[Provenance Plus](/plus/)** gives you iCloud save sync across all your Apple devices, early access via TestFlight, and priority support — and every subscription goes directly toward sustaining Provenance's development. Subscribe from within the app: *Settings > Provenance Plus*.
+
+---
+
 Thank you for being part of the Provenance community. Happy gaming!


### PR DESCRIPTION
## Summary
- Added a "Provenance Plus" section to the bottom of three release blog posts (before the closing "Thank you" line)
- Each callout is contextually worded to match the release it appears in:
  - **3.1.0**: Ties the callout into the new iCloud Sync feature introduced in that release
  - **3.1.1**: Emphasizes supporting the community-driven bug fix work
  - **3.2.1**: Highlights sustaining continued development through subscriptions
- All three link to the /plus/ page and mention the in-app subscription path (`Settings > Provenance Plus`)

## Part of
- Part of #36 (Add Provenance Plus callouts to blog posts)

## Test plan
- [ ] Hugo builds without errors (`hugo --minify`)
- [ ] Provenance Plus section renders correctly at the bottom of each blog post
- [ ] Links to `/plus/` resolve correctly
- [ ] Horizontal rule separators display correctly above each callout section
- [ ] Posts render at localhost:1313/blog/release3.1.0/, /release3.1.1/, and /release3.2.1/
- [ ] Callout wording feels natural and distinct across the three posts