### PR TITLE
perf: Improve Lighthouse performance score (57 → 70+)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -280,33 +280,37 @@ pygmentsStyle = "solarized-dark"
     # Plugins
     [params.plugins]
 
-        # CSS Plugins
+        # CSS Plugins (loaded on all pages)
         [[params.plugins.css]]
             URL = "plugins/bootstrap/bootstrap.min.css"
         [[params.plugins.css]]
             URL = "plugins/themefisher-font/style.css"
         [[params.plugins.css]]
-            URL = "plugins/owl-carousel/assets/owl.carousel.min.css"
-        [[params.plugins.css]]
-            URL = "plugins/owl-carousel/assets/owl.theme.green.min.css"
-        [[params.plugins.css]]
-            URL = "plugins/fancybox/jquery.fancybox.min.css"
-        [[params.plugins.css]]
             URL = "plugins/aos/aos.css"
         [[params.plugins.css]]
             URL = "css/provenance-custom.css"
 
-        # JS Plugins
+        # CSS Plugins (homepage-only — loaded conditionally in head.html)
+        [[params.plugins.css_homepage]]
+            URL = "plugins/owl-carousel/assets/owl.carousel.min.css"
+        [[params.plugins.css_homepage]]
+            URL = "plugins/owl-carousel/assets/owl.theme.green.min.css"
+        [[params.plugins.css_homepage]]
+            URL = "plugins/fancybox/jquery.fancybox.min.css"
+
+        # JS Plugins (loaded on all pages)
         [[params.plugins.js]]
             URL = "plugins/jquery/jquery.js"
         [[params.plugins.js]]
             URL = "plugins/bootstrap/bootstrap.min.js"
         [[params.plugins.js]]
-            URL = "plugins/owl-carousel/owl.carousel.min.js"
-        [[params.plugins.js]]
-            URL = "plugins/fancybox/jquery.fancybox.min.js"
-        [[params.plugins.js]]
             URL = "plugins/aos/aos.js"
+
+        # JS Plugins (homepage-only — loaded conditionally in footer.html)
+        [[params.plugins.js_homepage]]
+            URL = "plugins/owl-carousel/owl.carousel.min.js"
+        [[params.plugins.js_homepage]]
+            URL = "plugins/fancybox/jquery.fancybox.min.js"
 
 # https://github.com/kaushalmodi/hugo-atom-feed
 [outputs]

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -51,7 +51,7 @@
 				{{ end }}
 			</div>
 			<div class="col-md-6 text-center order-1 order-md-2">
-				<img src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" class="img-fluid" alt="banner-image">
+				<img src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" class="img-fluid" alt="banner-image" fetchpriority="high" decoding="async">
 			</div>
 			{{ end }}
 		</div>
@@ -156,7 +156,7 @@
 			<div class="col-lg-6 ml-auto justify-content-center">
 				{{ "<!-- Feature Mockup -->" | safeHTML }}
 				<div class="image-content" data-aos="fade-right">
-					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="iphone">
+					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="iphone" loading="lazy" decoding="async">
 				</div>
 			</div>
 			<div class="col-lg-6 mr-auto align-self-center">
@@ -209,7 +209,7 @@
 			<div class="col-lg-6 mr-auto justify-content-center">
 				{{ "<!-- Feature mockup -->" | safeHTML }}
 				<div class="image-content" data-aos="fade-left">
-					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="ipad">
+					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="ipad" loading="lazy" decoding="async">
 				</div>
 			</div>
 		</div>
@@ -235,7 +235,7 @@
 				<div class="mockup-slider owl-carousel owl-theme">
 					{{ range .Site.Data.homepage.mockupCarousel.items }}
 					<div class="item text-center">
-						<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="{{ .title }}">
+						<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="{{ .title }}" loading="lazy" decoding="async">
 						<h5 class="mt-3">{{ .title }}</h5>
 					</div>
 					{{ end }}
@@ -290,7 +290,7 @@
 		<div class="row no-gutters">
 			<div class="col-lg-6 align-self-center">
 				<div class="service-thumb left" data-aos="fade-right">
-					<img class="img-fluid service-thumb-img" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad">
+					<img class="img-fluid service-thumb-img" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad" loading="lazy" decoding="async">
 				</div>
 			</div>
 			<div class="col-lg-5 mr-auto align-self-center">
@@ -347,7 +347,7 @@
 						<div class="block shadow">
 							<p>{{ .content }}</p>
 							<div class="image">
-								<img src="{{ .image | absURL }}" alt="image">
+								<img src="{{ .image | absURL }}" alt="image" loading="lazy" decoding="async">
 							</div>
 							<cite>{{ .name }}</cite>
 						</div>
@@ -387,7 +387,7 @@
 						<h3 class="blog-card-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
 						<p class="blog-card-summary">{{ .Description | default .Summary }}</p>
 						<div class="blog-meta mt-auto">
-							<img src="{{ .Params.AuthorImage | absURL }}" alt="{{ .Params.Author }}" class="blog-author-img">
+							<img src="{{ .Params.AuthorImage | absURL }}" alt="{{ .Params.Author }}" class="blog-author-img" loading="lazy" decoding="async">
 							<span class="blog-author-name">{{ .Params.Author }}</span>
 							<span class="blog-meta-sep">·</span>
 							<span>{{ .PublishDate.Format "Jan 2, 2006" }}</span>
@@ -505,7 +505,7 @@
 				<div class="download-badges-row">
 					{{ range .Site.Data.homepage.download.downloadButton }}
 					<a href="{{ htmlEscape .URL }}" class="badge-link badge-link-download" title="{{ .btnText }}">
-						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-section">
+						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-section" loading="lazy" decoding="async">
 					</a>
 					{{ end }}
 				</div>

--- a/themes/small-apps-prov/layouts/partials/footer.html
+++ b/themes/small-apps-prov/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             <li class="list-inline-item mx-3"><a class="text-white" href="{{ .URL }}">{{ .Name }}</a></li>
             {{ end }}
           </ul>
-          <a href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logoAlt | absURL }}" alt="footer-logo"></a>
+          <a href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logoAlt | absURL }}" alt="footer-logo" loading="lazy" decoding="async"></a>
           <ul class="social-icon list-inline">
             {{ range .Site.Params.footer.socialIcon }}
             <li class="list-inline-item">
@@ -24,27 +24,17 @@
   </div>
 </footer>
 
-{{ $script:= "script" }}
-{{ $scriptTag:= "<" }}
-{{$scriptTag | safeHTML }}{{$script}} type="text/javascript">
-  
-  {{ $.Scratch.Set "counter" 0 }}
-  {{ range .Site.Params.plugins.css }}
-  {{ $.Scratch.Set "counter" (add ($.Scratch.Get "counter") 1) }}
-  var css{{$.Scratch.Get `counter`}} = document.createElement('link');
-  css{{$.Scratch.Get `counter`}}.rel = 'stylesheet';
-  css{{$.Scratch.Get `counter`}}.href = '{{ .URL | absURL }}';
-  css{{$.Scratch.Get `counter`}}.type = 'text/css';
-  var fastCSS{{$.Scratch.Get `counter`}} = document.getElementsByTagName('link')[0];
-  fastCSS{{$.Scratch.Get `counter`}}.parentNode.insertBefore(css{{$.Scratch.Get `counter`}}, fastCSS{{$.Scratch.Get `counter`}});
-  {{ end }}
 
-</script>
 
-  
 {{ "<!-- JS Plugins (deferred — does not block rendering) -->" | safeHTML }}
 {{ range .Site.Params.plugins.js}}
 <script src="{{ .URL | absURL }}" defer></script>
+{{ end }}
+{{ if .IsHome }}
+{{ "<!-- Homepage-only JS plugins (OWL Carousel, Fancybox) -->" | safeHTML }}
+{{ range .Site.Params.plugins.js_homepage }}
+<script src="{{ .URL | absURL }}" defer></script>
+{{ end }}
 {{ end }}
 {{ "<!-- Main Script -->" | safeHTML }}
 {{ $script := resources.Get "js/script.js" | minify}}

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -29,12 +29,18 @@
   {{ "<!-- Social metadata (Open Graph, Twitter Cards) -->" | safeHTML }}
   {{ partial "social_metadata.html" . }}
 
-  {{ "<!-- plugins -->" | safeHTML }}
-  <noscript>
-    {{ range .Site.Params.plugins.css }}
-    <link rel="stylesheet" href="{{ .URL | absURL }} ">
-    {{ end }}
-  </noscript>
+  {{ "<!-- plugins CSS (async, non-render-blocking) -->" | safeHTML }}
+  {{ range .Site.Params.plugins.css }}
+  <link rel="preload" href="{{ .URL | absURL }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
+  {{ end }}
+  {{ if .IsHome }}
+  {{ "<!-- Homepage-only CSS (OWL Carousel, Fancybox) -->" | safeHTML }}
+  {{ range .Site.Params.plugins.css_homepage }}
+  <link rel="preload" href="{{ .URL | absURL }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
+  {{ end }}
+  {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}


### PR DESCRIPTION
Part of #56

## Summary

- Replace synchronous inline-script CSS loader with `<link rel="preload" as="style" onload="...">` pattern in `<head>`, eliminating render-blocking JS on every page load
- Move OWL Carousel & Fancybox CSS/JS to homepage-only loading; blog & other pages no longer fetch unused carousel/lightbox assets
- Add `loading="lazy"` + `decoding="async"` to all below-fold images (feature sections, carousel, service, testimonials, blog authors, download badges, footer logo)
- Add `fetchpriority="high"` + `decoding="async"` to hero banner (LCP image)

## Test plan

- [ ] Hugo builds without errors
- [ ] Homepage renders correctly at localhost:1313
- [ ] OWL Carousel & testimonials still work on homepage
- [ ] Blog posts no longer load carousel/fancybox JS/CSS
- [ ] Run Lighthouse to verify score improvement

Generated with [Claude Code](https://claude.ai/code)