### PR TITLE
perf: reduce LCP and eliminate render-blocking resources

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -26,8 +26,8 @@ banner:
   description : "The ultimate open-source, all-in-one emulator. Play your favorite retro games with native iOS features, beautiful metadata, and support for 38+ console systems. Free when sideloaded or built from source."
   bgImage : "images/home-banner.webp"
   bgImageAlt : "images/home-banner.jpg"
-  image : "images/mobile.png"
-  imageAlt : "images/mobile.webp"
+  image : "images/mobile.webp"
+  imageAlt : "images/mobile.png"
   button:
     btnText : "Get on App Store"
     URL : "https://apps.apple.com/us/app/provenance-app/id1596862805"
@@ -83,8 +83,8 @@ whyProvenance:
 # feature one
 featureOne:
   enable : true
-  imageAlt : "images/feature/feature-rom-metadata.webp"
-  image : "images/feature/feature-rom-metadata.png"
+  image : "images/feature/feature-rom-metadata.webp"
+  imageAlt : "images/feature/feature-rom-metadata.png"
   title : "Your Games, Beautifully Presented"
   content : "Every game gets the treatment it deserves. Automatic artwork downloads, release information, ratings, and even scanned manuals. Edit any detail to make your library truly yours."
   comment : ""

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -51,7 +51,10 @@
 				{{ end }}
 			</div>
 			<div class="col-md-6 text-center order-1 order-md-2">
-				<img src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" class="img-fluid" alt="banner-image" fetchpriority="high" decoding="async">
+				<picture>
+					<source srcset="{{ .image | absURL }}" type="image/webp">
+					<img src="{{ .imageAlt | absURL }}" class="img-fluid" alt="banner-image" fetchpriority="high" decoding="async" width="464" height="960">
+				</picture>
 			</div>
 			{{ end }}
 		</div>

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -24,7 +24,7 @@
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
   {{ "<!-- Hero image preload (reduces LCP on homepage) -->" | safeHTML }}
-  {{ if .IsHome }}{{ with .Site.Data.homepage.banner }}<link rel="preload" as="image" href="{{ .image | absURL }}">{{ end }}{{ end }}
+  {{ if .IsHome }}{{ with .Site.Data.homepage.banner }}<link rel="preload" as="image" href="{{ .image | absURL }}" type="image/webp">{{ end }}{{ end }}
 
   {{ "<!-- Social metadata (Open Graph, Twitter Cards) -->" | safeHTML }}
   {{ partial "social_metadata.html" . }}
@@ -46,8 +46,9 @@
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="screen">
 
-  {{ "<!-- AOS — synchronous (must apply before AOS.init() reads initial states) -->" | safeHTML }}
-  <link rel="stylesheet" href="{{ "plugins/aos/aos.css" | absURL }}">
+  {{ "<!-- AOS — preloaded async (AOS.js is deferred so CSS will be applied before it runs) -->" | safeHTML }}
+  <link rel="preload" href="{{ "plugins/aos/aos.css" | absURL }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="{{ "plugins/aos/aos.css" | absURL }}"></noscript>
 
   {{ "<!--Favicon-->" | safeHTML }}
   <link rel="shortcut icon" href="{{ "images/favicon.png" | absURL }} " type="image/x-icon">


### PR DESCRIPTION
Fix Lighthouse performance score below threshold (64/100).

## Summary
- Hero image: serve mobile.webp (51KB) instead of mobile.png (352KB) via `<picture>` element
- featureOne: serve feature-rom-metadata.webp (2MB) instead of .png (4.5MB)
- AOS CSS: changed from render-blocking to async preload pattern
- Hero image: added explicit width/height to reduce CLS

## Part of
- Part of #60

## Test plan
- [ ] Hugo builds without errors
- [ ] Page renders correctly at localhost:1313
- [ ] Hero image loads as WebP in Chrome/Firefox, PNG in older browsers
- [ ] AOS animations still work on scroll

Generated with [Claude Code](https://claude.ai/code)