### PR TITLE
fix: blog page invisible — owlCarousel crash prevents AOS init

### DIFF
--- a/themes/small-apps-prov/assets/js/script.js
+++ b/themes/small-apps-prov/assets/js/script.js
@@ -7,94 +7,97 @@
   });
 
   $(function () {
-      // -----------------------------
-      //  Testimonial Slider
-      // -----------------------------
-      $('.testimonial-slider').owlCarousel({
-          loop: true,
-          margin: 20,
-          dots: true,
-          autoplay: true,
-          responsive: {
-              0: {
-                  items: 1
-              },
-              400: {
-                  items: 1
-              },
-              600: {
-                  items: 1
-              },
-              1000: {
-                  items: 2
+      // Owl Carousel is only loaded on the homepage; guard to avoid errors on other pages
+      if ($.fn.owlCarousel) {
+          // -----------------------------
+          //  Testimonial Slider
+          // -----------------------------
+          $('.testimonial-slider').owlCarousel({
+              loop: true,
+              margin: 20,
+              dots: true,
+              autoplay: true,
+              responsive: {
+                  0: {
+                      items: 1
+                  },
+                  400: {
+                      items: 1
+                  },
+                  600: {
+                      items: 1
+                  },
+                  1000: {
+                      items: 2
+                  }
               }
-          }
-      });
-      // -----------------------------
-      //  Story Slider
-      // -----------------------------
-      $('.about-slider').owlCarousel({
-          loop: true,
-          margin: 20,
-          dots: true,
-          autoplay: true,
-          items: 1
-      });
-      // -----------------------------
-      //  Quote Slider
-      // -----------------------------
-      $('.quote-slider').owlCarousel({
-          loop: true,
-          autoplay: true,
-          items: 1
-      });
-      // -----------------------------
-      //  Client Slider
-      // -----------------------------
-      $('.client-slider').owlCarousel({
-          loop: true,
-          autoplay: true,
-          margin: 50,
-          responsive: {
-              0: {
-                  items: 1,
-                  dots: false
-              },
-              400: {
-                  items: 2,
-                  dots: false
-              },
-              600: {
-                  items: 2,
-                  dots: false
-              },
-              1000: {
-                  items: 4
+          });
+          // -----------------------------
+          //  Story Slider
+          // -----------------------------
+          $('.about-slider').owlCarousel({
+              loop: true,
+              margin: 20,
+              dots: true,
+              autoplay: true,
+              items: 1
+          });
+          // -----------------------------
+          //  Quote Slider
+          // -----------------------------
+          $('.quote-slider').owlCarousel({
+              loop: true,
+              autoplay: true,
+              items: 1
+          });
+          // -----------------------------
+          //  Client Slider
+          // -----------------------------
+          $('.client-slider').owlCarousel({
+              loop: true,
+              autoplay: true,
+              margin: 50,
+              responsive: {
+                  0: {
+                      items: 1,
+                      dots: false
+                  },
+                  400: {
+                      items: 2,
+                      dots: false
+                  },
+                  600: {
+                      items: 2,
+                      dots: false
+                  },
+                  1000: {
+                      items: 4
+                  }
               }
-          }
-      });
-      // -----------------------------
-      //  Mockup Slider
-      // -----------------------------
-      $('.mockup-slider').owlCarousel({
-          loop: true,
-          margin: 30,
-          dots: true,
-          autoplay: true,
-          autoplayTimeout: 4000,
-          autoplayHoverPause: true,
-          responsive: {
-              0: {
-                  items: 1
-              },
-              600: {
-                  items: 2
-              },
-              1000: {
-                  items: 3
+          });
+          // -----------------------------
+          //  Mockup Slider
+          // -----------------------------
+          $('.mockup-slider').owlCarousel({
+              loop: true,
+              margin: 30,
+              dots: true,
+              autoplay: true,
+              autoplayTimeout: 4000,
+              autoplayHoverPause: true,
+              responsive: {
+                  0: {
+                      items: 1
+                  },
+                  600: {
+                      items: 2
+                  },
+                  1000: {
+                      items: 3
+                  }
               }
-          }
-      });
+          });
+      } // end if owlCarousel
       // -----------------------------
       //  Video Replace
       // -----------------------------


### PR DESCRIPTION
## Summary
- **Root cause:** `script.js` calls `.owlCarousel()` unconditionally. OWL Carousel JS is only loaded on the homepage (since PR #57 made it homepage-only). On the blog, plus, status, and all other pages, calling `.owlCarousel()` throws `TypeError: \$(...).owlCarousel is not a function`, which halts script.js execution before `AOS.init()` runs.
- **Symptom:** All elements with `data-aos` attributes on non-homepage pages stay invisible (`opacity: 0` set by AOS CSS, never cleared). The blog listing page appeared completely blank.
- **Fix:** Wrap all `owlCarousel` calls in `if ($.fn.owlCarousel)` — they skip silently when not loaded, and `AOS.init()` always runs.

## Test plan
- [ ] Hugo builds without errors  
- [ ] Blog listing page renders all cards visibly at `/blog/`
- [ ] Homepage carousel still works
- [ ] `/plus/`, `/status/`, and other non-homepage pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)