### PR TITLE
fix: increase SSL Labs polling timeout from 3 min to 5 min

### DIFF
--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -251,7 +251,7 @@ jobs:
         run: |
           curl -s "https://api.ssllabs.com/api/v3/analyze?host=provenance-emu.com&startNew=on&publish=off" > /dev/null
           GRADE="N/A"
-          for i in {1..9}; do
+          for i in {1..15}; do
             sleep 20
             RESULT=$(curl -s "https://api.ssllabs.com/api/v3/analyze?host=provenance-emu.com&publish=off")
             STATUS=$(echo "$RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Increases SSL Labs polling retries from 9 to 15 (9×20s = 3 min → 15×20s = 5 min)
- The SSL Labs scan was consistently staying `IN_PROGRESS` for all 9 attempts, causing the grade to report as `N/A` in status.json and the status page

## Part of
- Part of #15 (Technical health)

## Test plan
- [ ] Next audit run shows a real SSL grade (A or A+) instead of N/A