### PR TITLE
perf: reduce page payload — eliminate unused Fancybox, switch jQuery to CDN

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -293,12 +293,11 @@ pygmentsStyle = "solarized-dark"
             URL = "plugins/owl-carousel/assets/owl.carousel.min.css"
         [[params.plugins.css_homepage]]
             URL = "plugins/owl-carousel/assets/owl.theme.green.min.css"
-        [[params.plugins.css_homepage]]
-            URL = "plugins/fancybox/jquery.fancybox.min.css"
+        # Fancybox removed: promoVideo is disabled so data-fancybox never renders
 
         # JS Plugins (loaded on all pages)
         [[params.plugins.js]]
-            URL = "plugins/jquery/jquery.js"
+            URL = "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
         [[params.plugins.js]]
             URL = "plugins/bootstrap/bootstrap.min.js"
         [[params.plugins.js]]
@@ -307,8 +306,7 @@ pygmentsStyle = "solarized-dark"
         # JS Plugins (homepage-only — loaded conditionally in footer.html)
         [[params.plugins.js_homepage]]
             URL = "plugins/owl-carousel/owl.carousel.min.js"
-        [[params.plugins.js_homepage]]
-            URL = "plugins/fancybox/jquery.fancybox.min.js"
+        # Fancybox removed: promoVideo is disabled so data-fancybox never renders
 
 # https://github.com/kaushalmodi/hugo-atom-feed
 [outputs]

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -11,6 +11,7 @@
   {{ "<!-- DNS preconnects for external origins -->" | safeHTML }}
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 
   {{ "<!-- Font Awesome — async (non-render-blocking) -->" | safeHTML }}
@@ -50,8 +51,9 @@
   <link rel="stylesheet" href="{{ "plugins/aos/aos.css" | absURL }}">
 
   {{ "<!--Favicon-->" | safeHTML }}
-  <link rel="shortcut icon" href="{{ "images/icons/icon.512x512.png" | absURL }}" type="image/x-icon">
-  <link rel="icon" href="{{ "images/icons/icon.512x512.png" | absURL }}" type="image/png">
+  <link rel="shortcut icon" href="{{ "images/icons/icon.57x57.png" | absURL }}" type="image/x-icon">
+  <link rel="icon" href="{{ "images/icons/icon.57x57.png" | absURL }}" type="image/png">
+  <link rel="apple-touch-icon" href="{{ "images/icons/icon.512x512.png" | absURL }}">
 
   {{ "<!-- JSON-LD structured data -->" | safeHTML }}
   {{ partial "jsonld.html" . }}

--- a/themes/small-apps-prov/layouts/partials/header.html
+++ b/themes/small-apps-prov/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar main-nav navbar-expand-lg p-0">
   <div class="container">
-    <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logo | absURL }}" alt="logo"></a>
+    <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logo | absURL }}" alt="logo" decoding="async"></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav"
       aria-expanded="false" aria-label="Toggle navigation">
       <span class="tf-ion-android-menu"></span>

--- a/themes/small-apps-prov/static/plugins/themefisher-font/style.css
+++ b/themes/small-apps-prov/static/plugins/themefisher-font/style.css
@@ -7,6 +7,7 @@
     url('fonts/themefisher-font.svg?ug5hnh#themefisher-font') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 [class^="tf-"], [class*=" tf-"] {


### PR DESCRIPTION
Part of #70

## Summary
- Switch jQuery from local unminified (86KB) to CDN minified (3.7.1 on cdnjs)
- Remove unused Fancybox JS (52KB) and CSS (14KB) from homepage (promoVideo is disabled)
- Upgrade cdn.jsdelivr.net dns-prefetch to preconnect
- Fix favicon: 512x512 PNG (46KB) → 57x57 PNG (2.4KB) for shortcut icon; keep 512x512 as apple-touch-icon
- Add font-display: swap to themefisher-font to eliminate FOIT
- Add decoding=async to navbar logo

Generated with [Claude Code](https://claude.ai/code)