### PR TITLE
perf: eliminate render-blocking CSS and reduce unused SCSS

### DIFF
--- a/themes/small-apps-prov/assets/scss/style.scss
+++ b/themes/small-apps-prov/assets/scss/style.scss
@@ -30,15 +30,9 @@
 
 @import 'pages/404.scss';
 
-@import 'pages/career.scss';
-
 @import 'pages/faq.scss';
 
 @import 'pages/privacy.scss';
-
-@import 'pages/sign-in.scss';
-
-@import 'pages/comming-soon.scss';
 
 @import 'pages/contact.scss';
 

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -53,7 +53,7 @@
 			<div class="col-md-6 text-center order-1 order-md-2">
 				<picture>
 					<source srcset="{{ .image | absURL }}" type="image/webp">
-					<img src="{{ .imageAlt | absURL }}" class="img-fluid" alt="banner-image" fetchpriority="high" decoding="async" width="464" height="960">
+					<img src="{{ .imageAlt | absURL }}" class="img-fluid" alt="banner-image" fetchpriority="high" width="464" height="960">
 				</picture>
 			</div>
 			{{ end }}

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -42,9 +42,13 @@
   {{ end }}
   {{ end }}
 
-  {{ "<!-- Main Stylesheet -->" | safeHTML }}
+  {{ "<!-- Critical CSS: minimal above-the-fold styles inlined to prevent FOUC while main stylesheet loads asynchronously -->" | safeHTML }}
+  <style>body{overflow-x:hidden}.main-nav{background:#fff}.gradient-banner{position:relative;overflow:hidden}.ios-only{display:none}@supports (-webkit-touch-callout:none){.ios-only{display:inline}.ios-disable{display:none}}</style>
+
+  {{ "<!-- Main Stylesheet — deferred via media=print to eliminate render-blocking resource; critical styles inlined above -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="screen">
+  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"></noscript>
 
   {{ "<!-- AOS CSS must be synchronous: async load races with AOS.init() causing elements to stay invisible -->" | safeHTML }}
   <link rel="stylesheet" href="{{ "plugins/aos/aos.css" | absURL }}">


### PR DESCRIPTION
Part of #75

## Summary
- Defer main SCSS stylesheet via media=print/onload swap (same pattern already used for Bootstrap, eliminating it as a render-blocking resource); inline minimal critical CSS to prevent FOUC
- Remove `decoding="async"` from the LCP hero `<img>` (can delay Largest Contentful Paint)
- Drop three unused page-specific SCSS imports (career, sign-in, comming-soon) from global bundle

## Test plan
- [ ] Hugo builds without errors
- [ ] Page renders correctly at localhost:1313
- [ ] No visible FOUC on homepage
- [ ] Lighthouse score ≥ 70

Generated with [Claude Code](https://claude.ai/code)