### PR TITLE
perf: eliminate render-blocking CSS, preload LCP image, fix CLS

### DIFF
--- a/themes/small-apps-prov/assets/scss/_typography.scss
+++ b/themes/small-apps-prov/assets/scss/_typography.scss
@@ -1,5 +1,5 @@
-// Google Font Import
-@import url('https://fonts.googleapis.com/css?family=Lora:400,400i|Open+Sans:300,400,600,700,800');
+// Google Fonts are loaded asynchronously via <link> in head.html (with display=swap and media=print).
+// Removed @import here to eliminate the CSS @import chain that blocked rendering.
 
 // Body
 body{

--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -30,22 +30,22 @@
 				{{ $btn := . }}
 				<div class="hero-badges">
 					<a href="{{ .URL }}" class="badge-link badge-link-hero" title="{{ .btnText }}">
-						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-hero">
+						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>
 					<a href="{{ .URL2 }}" class="badge-link badge-link-hero ios-only" title="{{ .btnText2 }}">
-						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero">
+						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>
 					<a href="{{ $.Site.Params.cta.URL }}" data-toggle="modal" data-target="#appStoreQRModal" class="badge-link badge-link-hero ios-disable" title="Scan QR code to download on iPhone">
-						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero">
+						<img src="{{ .badge2 | absURL }}" alt="{{ .btnText2 }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>
 					<a href="{{ .URL3 }}" class="badge-link badge-link-hero" title="{{ .btnText3 }}">
-						<img src="{{ .badge3 | absURL }}" alt="{{ .btnText3 }}" class="download-badge download-badge-hero">
+						<img src="{{ .badge3 | absURL }}" alt="{{ .btnText3 }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>
 					{{ with .URL4 }}<a href="{{ . }}" class="badge-link badge-link-hero ios-only" title="{{ $btn.btnText4 }}">
-						<img src="{{ $btn.badge4 | absURL }}" alt="{{ $btn.btnText4 }}" class="download-badge download-badge-hero">
+						<img src="{{ $btn.badge4 | absURL }}" alt="{{ $btn.btnText4 }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>{{ end }}
 					{{ with .URL5 }}<a href="{{ . }}" class="badge-link badge-link-hero ios-only" title="{{ $btn.btnText5 }}">
-						<img src="{{ $btn.badge5 | absURL }}" alt="{{ $btn.btnText5 }}" class="download-badge download-badge-hero">
+						<img src="{{ $btn.badge5 | absURL }}" alt="{{ $btn.btnText5 }}" class="download-badge download-badge-hero" width="138" height="46">
 					</a>{{ end }}
 				</div>
 				{{ end }}
@@ -508,7 +508,7 @@
 				<div class="download-badges-row">
 					{{ range .Site.Data.homepage.download.downloadButton }}
 					<a href="{{ htmlEscape .URL }}" class="badge-link badge-link-download" title="{{ .btnText }}">
-						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-section" loading="lazy" decoding="async">
+						<img src="{{ .badge | absURL }}" alt="{{ .btnText }}" class="download-badge download-badge-section" width="168" height="56" loading="lazy" decoding="async">
 					</a>
 					{{ end }}
 				</div>

--- a/themes/small-apps-prov/layouts/partials/footer.html
+++ b/themes/small-apps-prov/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             <li class="list-inline-item mx-3"><a class="text-white" href="{{ .URL }}">{{ .Name }}</a></li>
             {{ end }}
           </ul>
-          <a href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logoAlt | absURL }}" alt="footer-logo" loading="lazy" decoding="async"></a>
+          <a href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logoAlt | absURL }}" alt="footer-logo" width="126" height="18" loading="lazy" decoding="async"></a>
           <ul class="social-icon list-inline">
             {{ range .Site.Params.footer.socialIcon }}
             <li class="list-inline-item">

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -13,9 +13,15 @@
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  {{ "<!-- Font Awesome — deferred via media=print (does not compete with render-blocking CSS for bandwidth) -->" | safeHTML }}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" media="print" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.media='all'">
+  {{ "<!-- Google Fonts — deferred via media=print; display=swap prevents FOIT; @import removed from SCSS -->" | safeHTML }}
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;1,400&family=Open+Sans:wght@300;400;600;700;800&display=swap" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;1,400&family=Open+Sans:wght@300;400;600;700;800&display=swap"></noscript>
+
+  {{ "<!-- Font Awesome — deferred via media=print -->" | safeHTML }}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" media="print" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.onload=null;this.media='all'">
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"></noscript>
 
   {{ "<!-- Canonical URL -->" | safeHTML }}
@@ -24,12 +30,13 @@
   {{ "<!-- Page title -->" | safeHTML }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
-  {{ "<!-- Hero image: fetchpriority=high on the img element is sufficient; preload removed to avoid bandwidth contention -->" | safeHTML }}
+  {{ "<!-- LCP image preload (homepage only): tells browser to fetch the hero image immediately, before layout is complete -->" | safeHTML }}
+  {{ if .IsHome }}<link rel="preload" as="image" href="{{ "/images/mobile.webp" | absURL }}" type="image/webp" fetchpriority="high">{{ end }}
 
   {{ "<!-- Social metadata (Open Graph, Twitter Cards) -->" | safeHTML }}
   {{ partial "social_metadata.html" . }}
 
-  {{ "<!-- plugins CSS — deferred via media=print (low priority so render-blocking CSS gets full bandwidth) -->" | safeHTML }}
+  {{ "<!-- plugins CSS — deferred via media=print -->" | safeHTML }}
   {{ range .Site.Params.plugins.css }}
   <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
@@ -42,13 +49,20 @@
   {{ end }}
   {{ end }}
 
-  {{ "<!-- Main Stylesheet (synchronous — provides layout/grid needed for hero LCP element) -->" | safeHTML }}
+  {{ "<!-- Critical CSS: minimal above-fold rules to prevent FOUC while all stylesheets load asynchronously." | safeHTML }}
+  {{ "     Covers: body overflow, navbar bg, hero gradient (::before circle), ios-only toggle, hero badge sizing. -->" | safeHTML }}
+  <style>body{overflow-x:hidden}.main-nav{background:#fff}.gradient-banner{padding:6rem 0;position:relative;overflow:hidden}.gradient-banner::before{content:'';position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:200%;height:200%;border-radius:50%;background-image:linear-gradient(45deg,#009ec5 0%,#2e7eed 20%,#02225b 50%)}.pull-top{margin-top:-100px}.ios-only{display:none}.hero-badges{display:flex;flex-wrap:wrap;gap:12px;align-items:center}.download-badge-hero{height:46px;width:auto}</style>
+
+  {{ "<!-- Main Stylesheet — deferred via media=print so it never blocks the render path." | safeHTML }}
+  {{ "     Above-fold critical styles are inlined above; noscript fallback loads synchronously for no-JS users. -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="screen">
+  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="print" onload="this.onload=null;this.media='all'">
+  <noscript><link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"></noscript>
 
   {{ "<!-- AOS: inline only the 3 animation types used on this site (fade-up/right/left). -->" | safeHTML }}
-  {{ "<!-- Replaces 25 KB aos.css with ~250 bytes; homepage-only since only index.html uses data-aos. -->" | safeHTML }}
-  {{ "<!-- Must stay synchronous: AOS CSS sets opacity:0 before AOS.init() runs; async would race. -->" | safeHTML }}
+  {{ "<!-- Replaces 28 KB aos.css with ~250 bytes; homepage-only since only index.html uses data-aos. -->" | safeHTML }}
+  {{ "<!-- IMPORTANT: must stay synchronous — AOS CSS sets opacity:0 on [data-aos] before AOS.init() runs. -->" | safeHTML }}
+  {{ "<!-- If async, the opacity reset races with AOS.init() and elements can remain permanently invisible. -->" | safeHTML }}
   {{ if .IsHome }}<style>[data-aos^=fade]{opacity:0;transition-property:opacity,transform}[data-aos^=fade].aos-animate{opacity:1;transform:translateZ(0)}[data-aos=fade-up]{transform:translate3d(0,100px,0)}[data-aos=fade-right]{transform:translate3d(-100px,0,0)}[data-aos=fade-left]{transform:translate3d(100px,0,0)}</style>{{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/themes/small-apps-prov/layouts/partials/header.html
+++ b/themes/small-apps-prov/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar main-nav navbar-expand-lg p-0">
   <div class="container">
-    <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logo | absURL }}" alt="logo" decoding="async"></a>
+    <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.Params.logo | absURL }}" alt="logo" width="126" height="18" decoding="async"></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav"
       aria-expanded="false" aria-label="Toggle navigation">
       <span class="tf-ion-android-menu"></span>


### PR DESCRIPTION
Part of #75

## Summary
- Remove Google Fonts @import from SCSS (CSS @import is render-blocking even inside deferred sheets); move to deferred <link> with display=swap
- Defer main style.scss via media=print/onload swap — no CSS now blocks render
- Inline ~300 bytes of critical CSS to prevent FOUC (hero gradient, navbar, badge sizing)
- Add rel=preload for LCP hero image (mobile.webp, homepage only)
- Add explicit width/height to navbar logo, footer logo, and all hero/download badges to eliminate CLS

## Test plan
- [ ] Hugo builds without errors
- [ ] Page renders correctly at localhost:1313 (hero gradient visible immediately, no FOUC)
- [ ] No elements stuck invisible (AOS opacity:0 handled by inline style)
- [ ] Lighthouse score ≥ 70

Generated with [Claude Code](https://claude.ai/code)