### PR TITLE
fix: improve Lighthouse performance score #81

### DIFF
--- a/themes/small-apps-prov/layouts/index.html
+++ b/themes/small-apps-prov/layouts/index.html
@@ -159,7 +159,10 @@
 			<div class="col-lg-6 ml-auto justify-content-center">
 				{{ "<!-- Feature Mockup -->" | safeHTML }}
 				<div class="image-content" data-aos="fade-right">
-					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="iphone" loading="lazy" decoding="async">
+					<picture>
+						<source srcset="{{ .image | absURL }}" type="image/webp">
+						<img class="img-fluid" src="{{ .imageAlt | absURL }}" alt="iphone" loading="lazy" decoding="async" width="1440" height="1823">
+					</picture>
 				</div>
 			</div>
 			<div class="col-lg-6 mr-auto align-self-center">
@@ -212,7 +215,7 @@
 			<div class="col-lg-6 mr-auto justify-content-center">
 				{{ "<!-- Feature mockup -->" | safeHTML }}
 				<div class="image-content" data-aos="fade-left">
-					<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="ipad" loading="lazy" decoding="async">
+					<img class="img-fluid" src="{{ .image | absURL }}" alt="ipad" loading="lazy" decoding="async" width="677" height="1367">
 				</div>
 			</div>
 		</div>
@@ -238,7 +241,10 @@
 				<div class="mockup-slider owl-carousel owl-theme">
 					{{ range .Site.Data.homepage.mockupCarousel.items }}
 					<div class="item text-center">
-						<img class="img-fluid" src="{{ .image | absURL }}" onerror="this.src='{{ .imageAlt | absURL }}'" alt="{{ .title }}" loading="lazy" decoding="async">
+						<picture>
+							<source srcset="{{ .image | absURL }}" type="image/webp">
+							<img class="img-fluid" src="{{ .imageAlt | absURL }}" alt="{{ .title }}" loading="lazy" decoding="async" width="579" height="1200">
+						</picture>
 						<h5 class="mt-3">{{ .title }}</h5>
 					</div>
 					{{ end }}
@@ -293,7 +299,7 @@
 		<div class="row no-gutters">
 			<div class="col-lg-6 align-self-center">
 				<div class="service-thumb left" data-aos="fade-right">
-					<img class="img-fluid service-thumb-img" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad" loading="lazy" decoding="async">
+					<img class="img-fluid service-thumb-img" src="{{ .Site.Data.homepage.service.image | absURL }}" onerror="this.src='{{ .Site.Data.homepage.service.imageAlt | absURL }}'" alt="iphone-ipad" loading="lazy" decoding="async" width="664" height="327">
 				</div>
 			</div>
 			<div class="col-lg-5 mr-auto align-self-center">
@@ -350,7 +356,7 @@
 						<div class="block shadow">
 							<p>{{ .content }}</p>
 							<div class="image">
-								<img src="{{ .image | absURL }}" alt="image" loading="lazy" decoding="async">
+								<img src="{{ .image | absURL }}" alt="image" loading="lazy" decoding="async" width="64" height="64">
 							</div>
 							<cite>{{ .name }}</cite>
 						</div>
@@ -390,7 +396,7 @@
 						<h3 class="blog-card-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
 						<p class="blog-card-summary">{{ .Description | default .Summary }}</p>
 						<div class="blog-meta mt-auto">
-							<img src="{{ .Params.AuthorImage | absURL }}" alt="{{ .Params.Author }}" class="blog-author-img" loading="lazy" decoding="async">
+							<img src="{{ .Params.AuthorImage | absURL }}" alt="{{ .Params.Author }}" class="blog-author-img" loading="lazy" decoding="async" width="26" height="26">
 							<span class="blog-author-name">{{ .Params.Author }}</span>
 							<span class="blog-meta-sep">·</span>
 							<span>{{ .PublishDate.Format "Jan 2, 2006" }}</span>

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -38,13 +38,13 @@
 
   {{ "<!-- plugins CSS — deferred via media=print -->" | safeHTML }}
   {{ range .Site.Params.plugins.css }}
-  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.media='all'">
+  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.onload=null;this.media='all'">
   <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
   {{ end }}
   {{ if .IsHome }}
   {{ "<!-- Homepage-only CSS (OWL Carousel) -->" | safeHTML }}
   {{ range .Site.Params.plugins.css_homepage }}
-  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.media='all'">
+  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.onload=null;this.media='all'">
   <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
   {{ end }}
   {{ end }}


### PR DESCRIPTION
Fix CLS and WebP image handling to improve Lighthouse performance score above 70 threshold.

## Summary
- Add explicit `width`/`height` to all homepage images missing dimensions to eliminate CLS
- Convert featureOne and mockup carousel images to proper `<picture>` elements with WebP sources
- Fix `onload` handler for deferred plugin CSS links

## Part of
- Part of #81 (Lighthouse performance score below threshold)

## Test plan
- [ ] Hugo builds without errors
- [ ] Homepage renders correctly at localhost:1313
- [ ] Feature images load as WebP in Chrome, PNG in older browsers
- [ ] Lighthouse score ≥ 70

Generated with [Claude Code](https://claude.ai/code)