### PR TITLE
fix: resolve HTML link check failure — broken AltStore icon URL

### DIFF
--- a/static/img/altstore-icon.svg
+++ b/static/img/altstore-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="14" fill="#00C9A7"/>
+  <text x="32" y="46" font-family="Arial, sans-serif" font-size="38" font-weight="bold" text-anchor="middle" fill="white">A</text>
+</svg>

--- a/themes/small-apps-prov/layouts/install/list.html
+++ b/themes/small-apps-prov/layouts/install/list.html
@@ -44,7 +44,7 @@
     {{/* ── AltStore ── */}}
     <div class="row align-items-center mb-5 pb-5" style="border-bottom:1px solid #eee;">
       <div class="col-md-2 text-center mb-3 mb-md-0">
-        <img src="https://altstore.io/assets/icon.png" width="64" height="64" alt="AltStore" style="border-radius:14px;" onerror="this.style.display='none'">
+        <img src="/img/altstore-icon.svg" width="64" height="64" alt="AltStore" style="border-radius:14px;">
       </div>
       <div class="col-md-7">
         <h2 class="font-weight-bold mb-1">AltStore</h2>


### PR DESCRIPTION
Part of #88

## Summary

- Replaced broken external URL `https://altstore.io/assets/icon.png` (404) with a locally hosted SVG icon
- Created `static/img/altstore-icon.svg` as a branded placeholder
- Updated `themes/small-apps-prov/layouts/install/list.html` to reference local path

## Test plan
- [ ] Hugo builds without errors
- [ ] `/install/` page renders AltStore section correctly
- [ ] htmlproofer passes with 0 failures

Generated with [Claude Code](https://claude.ai/code)