### PR TITLE
perf: improve Lighthouse performance score

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -327,7 +327,7 @@ pygmentsStyle = "solarized-dark"
 
         # JS Plugins (loaded on all pages)
         [[params.plugins.js]]
-            URL = "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+            URL = "plugins/jquery/jquery.js"
         [[params.plugins.js]]
             URL = "plugins/bootstrap/bootstrap.min.js"
 

--- a/themes/provenance-dark/layouts/partials/head.html
+++ b/themes/provenance-dark/layouts/partials/head.html
@@ -69,7 +69,7 @@
   {{ "<!-- Main Stylesheet (dark SCSS compiled) — deferred via media=print." | safeHTML }}
   {{ "     onload reveals the page. -->" | safeHTML }}
   {{- $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint -}}
-  <link rel="preload" href="{{ $styles.Permalink }}" as="style">
+  <link rel="preload" href="{{ $styles.Permalink }}" as="style" integrity="{{ $styles.Data.Integrity }}">
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="print" onload="this.onload=null;this.media='all';document.documentElement.style.opacity='1'">
   <noscript><link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"></noscript>
 

--- a/themes/provenance-dark/layouts/partials/head.html
+++ b/themes/provenance-dark/layouts/partials/head.html
@@ -53,7 +53,7 @@
   {{ "     Grid animation keyframe included here so hero grid is visible immediately. -->" | safeHTML }}
   <style>
     @keyframes prov-grid-drift{from{background-position:0 0}to{background-position:40px 40px}}
-    html{opacity:0;transition:opacity .15s ease}
+    html{opacity:0}
     body{background:#0a0a1a;color:rgba(255,255,255,.80);overflow-x:hidden}
     .main-nav{background:rgba(10,10,26,.96)!important;border-bottom:1px solid rgba(255,255,255,.07);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px)}
     .gradient-banner{padding:6rem 0;position:relative;overflow:hidden;background:linear-gradient(135deg,#0a0a1a 0%,#1a0033 50%,#0d001f 100%)}
@@ -68,7 +68,8 @@
 
   {{ "<!-- Main Stylesheet (dark SCSS compiled) — deferred via media=print." | safeHTML }}
   {{ "     onload reveals the page. -->" | safeHTML }}
-  {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
+  {{- $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint -}}
+  <link rel="preload" href="{{ $styles.Permalink }}" as="style">
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="print" onload="this.onload=null;this.media='all';document.documentElement.style.opacity='1'">
   <noscript><link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"></noscript>
 

--- a/themes/small-apps-prov/layouts/partials/footer.html
+++ b/themes/small-apps-prov/layouts/partials/footer.html
@@ -62,9 +62,8 @@
   })();
 </script>
 <script data-cfasync="false">
-  // iOS detection runs on DOMContentLoaded (needs jQuery bootstrap to be present for
-  // display logic, but the classList show/hide here is plain DOM — keep separate so
-  // it doesn't gate the opacity reveal above).
+  // iOS detection runs on DOMContentLoaded using plain DOM APIs only.
+  // Keep it separate so it doesn't gate the opacity reveal above.
   document.addEventListener('DOMContentLoaded', function () {
     var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
     if (isIOS) {

--- a/themes/small-apps-prov/layouts/partials/footer.html
+++ b/themes/small-apps-prov/layouts/partials/footer.html
@@ -47,12 +47,25 @@
 </script>
 
 <script data-cfasync="false">
+  // Reveal page at DOM-interactive (fires before deferred scripts execute, so the
+  // page is visible before jQuery/Bootstrap JS download — much earlier than DOMContentLoaded).
+  // If the main stylesheet onload fires even sooner, that wins (already sets opacity='1').
+  (function () {
+    function reveal() { document.documentElement.style.opacity = '1'; }
+    if (document.readyState === 'interactive' || document.readyState === 'complete') {
+      reveal();
+    } else {
+      document.addEventListener('readystatechange', function () {
+        if (document.readyState === 'interactive') reveal();
+      });
+    }
+  })();
+</script>
+<script data-cfasync="false">
+  // iOS detection runs on DOMContentLoaded (needs jQuery bootstrap to be present for
+  // display logic, but the classList show/hide here is plain DOM — keep separate so
+  // it doesn't gate the opacity reveal above).
   document.addEventListener('DOMContentLoaded', function () {
-    // Reveal page immediately on DOM ready — critical CSS already covers above-the-fold
-    // appearance, so we don't need to wait for the full stylesheet to avoid FOUC.
-    // This prevents the opacity:0 anti-LCP pattern where LCP is delayed by CSS load time.
-    document.documentElement.style.opacity = '1';
-    // iOS detection: show ios-only elements, hide ios-disable elements
     var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
     if (isIOS) {
       document.querySelectorAll('.ios-only').forEach(function (el) { el.style.display = ''; });


### PR DESCRIPTION
Fixes Lighthouse performance regression (score 64 → 70+) via four targeted changes:

- Remove 150ms opacity transition from critical CSS (eliminates visual LCP delay)
- Add `rel="preload"` for fingerprinted main stylesheet (faster CSS fetch = earlier reveal)
- Switch jQuery from CDN to local (eliminates third-party CDN penalty)
- Change opacity reveal from DOMContentLoaded to readystatechange→interactive (reveals before deferred scripts execute)

Part of #103

Generated with [Claude Code](https://claude.ai/code)