### PR TITLE
fix: improve Lighthouse performance score

### DIFF
--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -15,6 +15,7 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://api.qrserver.com">
 
   {{ "<!-- Google Fonts — deferred via media=print; display=swap prevents FOIT; @import removed from SCSS -->" | safeHTML }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;1,400&family=Open+Sans:wght@300;400;600;700;800&display=swap" media="print" onload="this.onload=null;this.media='all'">
@@ -36,31 +37,31 @@
   {{ "<!-- Social metadata (Open Graph, Twitter Cards) -->" | safeHTML }}
   {{ partial "social_metadata.html" . }}
 
-  {{ "<!-- plugins CSS — deferred via media=print -->" | safeHTML }}
+  {{ "<!-- plugins CSS — preloaded (rel=preload as=style gives higher download priority than media=print) -->" | safeHTML }}
   {{ range .Site.Params.plugins.css }}
-  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.onload=null;this.media='all'">
+  <link rel="preload" as="style" href="{{ .URL | absURL }}" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
   {{ end }}
   {{ if .IsHome }}
   {{ "<!-- Homepage-only CSS (OWL Carousel) -->" | safeHTML }}
   {{ range .Site.Params.plugins.css_homepage }}
-  <link rel="stylesheet" href="{{ .URL | absURL }}" media="print" onload="this.onload=null;this.media='all'">
+  <link rel="preload" as="style" href="{{ .URL | absURL }}" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="{{ .URL | absURL }}"></noscript>
   {{ end }}
   {{ end }}
 
-  {{ "<!-- Critical CSS: minimal above-fold rules to prevent FOUC while all stylesheets load asynchronously." | safeHTML }}
-  {{ "     html opacity:0 hides the page until the main stylesheet is ready, preventing the broken-layout flash." | safeHTML }}
-  {{ "     The transition fades it in smoothly. noscript removes the opacity so no-JS users always see the page." | safeHTML }}
-  {{ "     Covers: body overflow, navbar bg, hero gradient (::before circle), ios-only toggle, hero badge sizing. -->" | safeHTML }}
-  <style>html{opacity:0;transition:opacity .15s ease}body{overflow-x:hidden}.main-nav{background:#fff}.gradient-banner{padding:6rem 0;position:relative;overflow:hidden}.gradient-banner::before{content:'';position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:200%;height:200%;border-radius:50%;background-image:linear-gradient(45deg,#009ec5 0%,#2e7eed 20%,#02225b 50%)}.pull-top{margin-top:-100px}.ios-only{display:none}.hero-badges{display:flex;flex-wrap:wrap;gap:12px;align-items:center}.download-badge-hero{height:46px;width:auto}</style>
+  {{ "<!-- Critical CSS: above-fold rules to prevent FOUC and CLS while stylesheets load asynchronously." | safeHTML }}
+  {{ "     Dark-mode defaults match dark-theme.css so no color flash occurs when it loads (dark is the site default)." | safeHTML }}
+  {{ "     Bootstrap grid critical rules (container/row/col-md-6) prevent layout shifts when Bootstrap CSS loads." | safeHTML }}
+  {{ "     html opacity:0 hides the page until the main stylesheet is ready; noscript and readystate reveal it. -->" | safeHTML }}
+  <style>html{opacity:0;transition:opacity .15s ease}body{overflow-x:hidden;background-color:#0a0a1a;color:rgba(255,255,255,.8)}.main-nav{background:rgba(10,10,26,.96)!important}.gradient-banner{padding:6rem 0;position:relative;overflow:hidden;background:linear-gradient(135deg,#0a0a1a 0%,#1a0033 50%,#0d001f 100%)}.pull-top{margin-top:-100px}.ios-only{display:none}.hero-badges{display:flex;flex-wrap:wrap;gap:12px;align-items:center}.download-badge-hero{height:46px;width:auto}.container{width:100%;padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}@media(min-width:992px){.container{max-width:960px}}@media(min-width:1200px){.container{max-width:1140px}}.row{display:flex;flex-wrap:wrap;margin-right:-15px;margin-left:-15px}.col-md-6{position:relative;width:100%;padding-right:15px;padding-left:15px}@media(min-width:768px){.col-md-6{flex:0 0 50%;max-width:50%}}.align-items-center{align-items:center!important}.text-center{text-align:center!important}.order-1{order:1}.order-2{order:2}@media(min-width:768px){.order-md-1{order:1}.order-md-2{order:2}}.img-fluid{max-width:100%;height:auto}</style>
   <noscript><style>html{opacity:1!important}</style></noscript>
 
-  {{ "<!-- Main Stylesheet — deferred via media=print so it never blocks the render path." | safeHTML }}
-  {{ "     onload also reveals the page (clears the opacity:0 set in critical CSS above)." | safeHTML }}
+  {{ "<!-- Main Stylesheet — preloaded at high priority; onload reveals the page when ready." | safeHTML }}
+  {{ "     rel=preload as=style downloads the stylesheet without blocking rendering, then applies it on load." | safeHTML }}
   {{ "     noscript fallback loads synchronously for no-JS users (opacity reset is handled by the noscript style above). -->" | safeHTML }}
   {{ $styles := resources.Get "scss/style.scss" | toCSS | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" media="print" onload="this.onload=null;this.media='all';document.documentElement.style.opacity='1'">
+  <link rel="preload" as="style" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}" onload="this.onload=null;this.rel='stylesheet';document.documentElement.style.opacity='1'">
   <noscript><link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"></noscript>
 
   {{ "<!-- AOS: inline only the 3 animation types used on this site (fade-up/right/left). -->" | safeHTML }}


### PR DESCRIPTION
Fix primary CLS sources and CSS download latency to push Lighthouse performance score above 70.

## Summary
- Align critical inline CSS with dark-theme.css defaults (dark body/navbar/hero) to eliminate white→dark color flash on load (biggest CLS contributor)
- Add Bootstrap grid critical rules (container, row, col-md-6, flex utils) to prevent layout shift when Bootstrap CSS loads
- Switch plugin CSS and main SCSS from `media="print"` to `rel="preload" as="style"` for higher-priority downloads
- Add dns-prefetch for api.qrserver.com

## Part of
- Part of #105

## Test plan
- [ ] Hugo builds without errors
- [ ] Dark mode renders correctly with no white flash on load
- [ ] Hero section layout is stable from first paint
- [ ] Lighthouse performance score ≥ 70

Generated with [Claude Code](https://claude.ai/code)