### PR TITLE
fix: reduce Lighthouse CI noise and drop unused preconnect

### DIFF
--- a/.github/workflows/site-audit.yml
+++ b/.github/workflows/site-audit.yml
@@ -177,20 +177,20 @@ jobs:
           if [ -z "$(find "$SEARCH_DIR" -name "lhr-*.json" 2>/dev/null | head -1)" ]; then
             SEARCH_DIR="."
           fi
-          # Pick the LHR for the homepage URL specifically (not /blog/ or /plus/)
-          REPORT=""
+          # Collect all LHRs for the homepage URL (3 runs → 3 files)
+          HOMEPAGE_LHRS=()
           for f in $(find "$SEARCH_DIR" -maxdepth 6 -name "lhr-*.json" 2>/dev/null); do
             URL_IN_LHR=$(jq -r '.requestedUrl // .finalUrl // ""' "$f" 2>/dev/null)
             if [[ "$URL_IN_LHR" == "https://provenance-emu.com" || "$URL_IN_LHR" == "https://provenance-emu.com/" ]]; then
-              REPORT="$f"
-              break
+              HOMEPAGE_LHRS+=("$f")
             fi
           done
-          # Fallback to first available LHR if homepage not found
-          if [ -z "$REPORT" ]; then
-            REPORT=$(find "$SEARCH_DIR" -maxdepth 6 -name "lhr-*.json" 2>/dev/null | head -1)
+          # Fallback to all LHRs if homepage-specific ones not found
+          if [ "${#HOMEPAGE_LHRS[@]}" -eq 0 ]; then
+            while IFS= read -r line; do HOMEPAGE_LHRS+=("$line"); done \
+              < <(find "$SEARCH_DIR" -maxdepth 6 -name "lhr-*.json" 2>/dev/null)
           fi
-          if [ -z "$REPORT" ]; then
+          if [ "${#HOMEPAGE_LHRS[@]}" -eq 0 ]; then
             echo "No LHR file found, using zeros"
             echo "performance=0" >> $GITHUB_OUTPUT
             echo "accessibility=0" >> $GITHUB_OUTPUT
@@ -199,11 +199,47 @@ jobs:
             echo "report_url=" >> $GITHUB_OUTPUT
             exit 0
           fi
-          echo "Using LHR: $REPORT ($(jq -r '.requestedUrl' "$REPORT" 2>/dev/null))"
-          PERF=$(jq '(.categories.performance.score    // 0) * 100 | round' < "$REPORT")
-          A11Y=$(jq '(.categories.accessibility.score  // 0) * 100 | round' < "$REPORT")
-          BP=$(jq '(."categories"."best-practices".score // 0) * 100 | round' < "$REPORT")
-          SEO=$(jq '(.categories.seo.score             // 0) * 100 | round' < "$REPORT")
+          echo "Found ${#HOMEPAGE_LHRS[@]} homepage LHR(s): ${HOMEPAGE_LHRS[*]}"
+          # Compute median across runs, discarding outliers >2 std deviations from mean
+          median_filtered() {
+            local cat="$1"; shift
+            python3 - "$cat" "$@" <<'PYEOF'
+          import sys, json, math
+          cat = sys.argv[1]
+          files = sys.argv[2:]
+          scores = []
+          for f in files:
+            try:
+              with open(f) as fh:
+                d = json.load(fh)
+              v = d.get("categories", {}).get(cat, {}).get("score")
+              if v is not None:
+                scores.append(round(v * 100))
+            except Exception:
+              pass
+          if not scores:
+            print(0); sys.exit(0)
+          if len(scores) >= 3:
+            mean = sum(scores) / len(scores)
+            variance = sum((x - mean) ** 2 for x in scores) / len(scores)
+            std = math.sqrt(variance)
+            if std > 0:
+              filtered = [x for x in scores if abs(x - mean) <= 2 * std]
+              if filtered:
+                scores = filtered
+          scores.sort()
+          mid = len(scores) // 2
+          if len(scores) % 2 == 1:
+            print(scores[mid])
+          else:
+            print(round((scores[mid - 1] + scores[mid]) / 2))
+          PYEOF
+          }
+          PERF=$(median_filtered "performance"    "${HOMEPAGE_LHRS[@]}")
+          A11Y=$(median_filtered "accessibility"  "${HOMEPAGE_LHRS[@]}")
+          BP=$(median_filtered   "best-practices" "${HOMEPAGE_LHRS[@]}")
+          SEO=$(median_filtered  "seo"            "${HOMEPAGE_LHRS[@]}")
+          echo "Scores (median, outliers filtered): perf=$PERF a11y=$A11Y bp=$BP seo=$SEO"
           echo "performance=$PERF" >> $GITHUB_OUTPUT
           echo "accessibility=$A11Y" >> $GITHUB_OUTPUT
           echo "best_practices=$BP" >> $GITHUB_OUTPUT

--- a/.lighthouserc.yml
+++ b/.lighthouserc.yml
@@ -1,6 +1,10 @@
 ci:
   collect:
-    numberOfRuns: 1
+    # 3 runs + median aggregation smooths out the CPU/network variance that's
+    # common on shared GitHub Actions runners — a single run can easily swing
+    # 15-20 performance points from noise alone, causing false-positive
+    # regression issues to be opened against an unchanged site.
+    numberOfRuns: 3
     settings:
       chromeFlags: '--no-sandbox --disable-dev-shm-usage'
   assert:
@@ -9,7 +13,7 @@ ci:
       # Minimum thresholds — issues will be created below these
       categories:performance:
         minScore: 0.70
-        aggregationMethod: optimistic
+        aggregationMethod: median
       categories:accessibility:
         minScore: 0.80
         aggregationMethod: optimistic

--- a/themes/provenance-dark/layouts/partials/head.html
+++ b/themes/provenance-dark/layouts/partials/head.html
@@ -11,8 +11,6 @@
   {{ "<!-- DNS preconnects for external origins -->" | safeHTML }}
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 

--- a/themes/small-apps-prov/layouts/partials/head.html
+++ b/themes/small-apps-prov/layouts/partials/head.html
@@ -11,8 +11,6 @@
   {{ "<!-- DNS preconnects for external origins -->" | safeHTML }}
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="dns-prefetch" href="https://api.qrserver.com">


### PR DESCRIPTION
## Summary
- Bumped .lighthouserc.yml numberOfRuns from 1 to 3 with median aggregation for the performance category, since a single Lighthouse run on a shared GitHub Actions runner is known to swing 15-20 points from CPU/network variance alone.
- Removed the unused cdn.jsdelivr.net preconnect/dns-prefetch hints from both head.html partials (small-apps-prov and provenance-dark) since nothing on the site loads from that origin.
- Found that themes/small-apps-prov/layouts/partials/head.html and header.html are currently shadowed/unused: Hugo resolves them from themes/provenance-dark instead, since that theme is listed first in config.toml. Future performance work on head.html should target the provenance-dark copy.

## Known limitation
This sandbox had no outbound network access, so the linked Lighthouse report could not be fetched and hugo/lighthouse could not be run locally to verify a score improvement. Also could not push an update to .github/workflows/site-audit.yml, whose score-extraction step still picks a single arbitrary LHR file instead of medianing the new 3 runs, because this GitHub App lacks workflows permission. A maintainer should apply that follow-up by hand — see the commit message for the intended diff.

## Part of
- Part of #110

## Test plan
- [ ] Hugo builds without errors
- [ ] Page renders correctly at localhost:1313
- [ ] Manually update site-audit.yml score extraction to median 3 runs, then confirm next audit reflects it

🤖 Generated with [Claude Code](https://claude.ai/code)